### PR TITLE
fix: pass suite name as ViewFilter in OpenForm to initialize CurrentSuiteName

### DIFF
--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -18,8 +18,8 @@ using StreamJsonRpc;
 //   4. Output per-method results
 //
 // Note: The DEFAULT test suite must be pre-created (via SQL in run-tests.sh).
-// The WebSocket protocol does not support SaveValue for setting page variables
-// like CurrentSuiteName. This is an implementation detail — the external
+// The suite is opened by filtering TableView to Name=suiteName, which positions
+// the page on the correct record so OnOpenPage sets CurrentSuiteName correctly.
 // interface matches BcContainerHelper's behavior.
 
 var host = "localhost:7085";
@@ -232,7 +232,7 @@ async Task<JToken?> OpenTestPage(JsonRpc rpc, MetadataTokenCapture tc, string co
     var formCts = CancellationTokenSource.CreateLinkedTokenSource(ct); formCts.CancelAfter(TimeSpan.FromSeconds(30));
     var form = await rpc.InvokeWithCancellationAsync<JToken>("OpenForm",
         new object[] { new { HasMainForm = true, States = new[] { new {
-            FormId = 130455, TableView = new { TableId = 130450 }
+            FormId = 130455, TableView = new { TableId = 130450, View = $"WHERE(Name=CONST({suiteName}))" }
         } }, ControlIds = new string?[] { null }, VersionNumber = tc.MetadataToken, MainFormHandle = Guid.Empty } }, formCts.Token);
     if (form == null || form.Type == JTokenType.Null) { Console.Error.WriteLine("FAIL"); return null; }
     var state = form["States"]?[0];


### PR DESCRIPTION
## Problem

When `Program.cs` opens page 130455 (AL Test Runner / Command Line Test Tool) via WebSocket, the `OpenForm` call only specified `TableId = 130450` in the `TableView`. On a fresh BC container with no persisted user session, the page's `CurrentSuiteName` variable defaults to `''` (empty string).

When `RunNextTest` is invoked, BC internally does `TestSuite.GET(CurrentSuiteName)` with an empty key, finds no record, and throws:
```
The AL Test Suite does not exist. Identification fields and values: Name=''
```

The reconnect loop in the catch block then re-opens the same page in the same broken state, repeating every ~2 seconds for the full timeout duration (60 min = ~1800 failed cycles, 0 tests executed).

Note: the DEFAULT suite **does** exist in the DB — it was correctly pre-created by `run-tests.sh` via SQL. The issue is purely page initialization.

## Fix

Add a `View` filter to the `TableView` in the `OpenForm` call:
```csharp
TableView = new { TableId = 130450, View = $"WHERE(Name=CONST({suiteName}))" }
```

This positions page 130455 on the correct suite record immediately on open, so `OnOpenPage` can initialize `CurrentSuiteName` from the current record. The `suiteName` variable is already parsed from the `--suite` argument.

## Backup plan (if ViewFilter is not supported by the BC NST WebSocket protocol)

If the BC client services protocol does not support the `View` field on `TableView`, the fallback is to insert an AL Test Suite record with `Name=''` in SQL alongside the DEFAULT suite, so `TestSuite.GET('')` succeeds regardless.