### PR TITLE
fix: proactive per-iteration reconnect in WebSocket test runner

### DIFF
--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -263,7 +263,8 @@ jobs:
         ./scripts/run-tests.sh \
           --app /tmp/testapp/SmokeTest.app \
           --codeunit-range 70000..70001 \
-          --timeout 10
+          --timeout 10 \
+          --codeunit-timeout 3
 
     - name: Summary
       if: always()

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -263,7 +263,7 @@ jobs:
         ./scripts/run-tests.sh \
           --app /tmp/testapp/SmokeTest.app \
           --codeunit-range 70000..70001 \
-          --timeout 5
+          --timeout 10
 
     - name: Summary
       if: always()

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -175,19 +175,50 @@ jobs:
         }
         APPJSON
 
+        # Two codeunits with two tests each — exercises the multi-codeunit reconnect fix.
+        # Each codeunit run triggers a BC test-isolation session kill; the runner must
+        # reconnect and advance to the next codeunit for both to complete.
         cat > /tmp/testapp/SmokeTest.Codeunit.al << 'ALCODE'
-        codeunit 70000 "BC Linux Smoke Test"
+        codeunit 70000 "BC Linux Smoke Test 1"
         {
             Subtype = Test;
             TestPermissions = Disabled;
 
             [Test]
-            procedure TestBCOnLinuxWorks()
+            procedure TestDateSanity()
             begin
                 if Today() < 20200101D then
                     Error('Date sanity check failed: %1', Today());
-                if 42 <> 42 then
-                    Error('Basic integer equality failed');
+            end;
+
+            [Test]
+            procedure TestBasicArithmetic()
+            begin
+                if 6 * 7 <> 42 then
+                    Error('Basic arithmetic failed');
+            end;
+        }
+
+        codeunit 70001 "BC Linux Smoke Test 2"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            [Test]
+            procedure TestStringConcatenation()
+            var
+                Result: Text;
+            begin
+                Result := 'Hello' + ', ' + 'World';
+                if Result <> 'Hello, World' then
+                    Error('String concatenation failed: %1', Result);
+            end;
+
+            [Test]
+            procedure TestBooleanLogic()
+            begin
+                if not (true and not false) then
+                    Error('Boolean logic failed');
             end;
         }
         ALCODE
@@ -228,11 +259,11 @@ jobs:
       env:
         BC_VERSION: ${{ matrix.bc_version }}
       run: |
-        echo "Running tests..."
+        echo "Running tests (2 codeunits × 2 methods — exercises multi-codeunit reconnect)..."
         ./scripts/run-tests.sh \
           --app /tmp/testapp/SmokeTest.app \
-          --codeunit-range 70000 \
-          --timeout 3
+          --codeunit-range 70000..70001 \
+          --timeout 5
 
     - name: Summary
       if: always()

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -56,6 +56,11 @@ done
 
 echo "=== BC Test Runner ==="
 
+if [ "$CODEUNIT_TIMEOUT_MIN" -ge "$TIMEOUT_MIN" ]; then
+    echo "WARNING: --codeunit-timeout ($CODEUNIT_TIMEOUT_MIN min) >= --timeout ($TIMEOUT_MIN min)." \
+         "The watchdog will fire at the same time as the overall timeout, leaving no room to reconnect for subsequent codeunits."
+fi
+
 # --- Detect SQL container ---
 SQL_CONTAINER=$(cd "$REPO_DIR" && docker compose ps -q sql 2>/dev/null | head -1)
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,6 +15,7 @@
 #   --test-runner <id>         Test runner codeunit ID (default: 130451)
 #   --suite-name <name>        Test suite name (default: DEFAULT)
 #   --timeout <minutes>        Overall timeout (default: 30)
+#   --codeunit-timeout <min>   Max time for one codeunit run before watchdog reconnects (default: 10)
 #   --disabled-tests <file>    Path to disabled tests JSON
 #   --sql-password <pw>        SA password for company auto-detect
 
@@ -27,6 +28,7 @@ TEST_RUNNER_ID=130451
 CODEUNIT_RANGE=""
 EXTENSION_ID=""
 TIMEOUT_MIN=30
+CODEUNIT_TIMEOUT_MIN=10
 SUITE_NAME="DEFAULT"
 DISABLED_TESTS=""
 SQL_PASSWORD="${SA_PASSWORD:-Passw0rd123!}"
@@ -45,6 +47,7 @@ while [[ $# -gt 0 ]]; do
         --test-runner) TEST_RUNNER_ID="$2"; shift 2;;
         --suite-name) SUITE_NAME="$2"; shift 2;;
         --timeout) TIMEOUT_MIN="$2"; shift 2;;
+        --codeunit-timeout) CODEUNIT_TIMEOUT_MIN="$2"; shift 2;;
         --disabled-tests) DISABLED_TESTS="$2"; shift 2;;
         --sql-password) SQL_PASSWORD="$2"; shift 2;;
         *) echo "Unknown option: $1"; exit 1;;
@@ -224,6 +227,7 @@ echo "  Suite '$SUITE_NAME' exists: ${SUITE_CHECK:-0} rows"
 # execution (test isolation), so we ignore the exit code and read results from SQL.
 timeout "${TIMEOUT_MIN}m" dotnet run --project "$TESTRUNNER_DIR" --no-build -c Release -- \
     --host "$BC_HOST" --company "$COMPANY" --suite "$SUITE_NAME" --timeout "$TIMEOUT_MIN" \
+    --codeunit-timeout "$CODEUNIT_TIMEOUT_MIN" \
     --max-iterations $(( ${CU_COUNT:-100} + 2 )) 2>&1 || true
 
 sleep 2

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -223,7 +223,8 @@ echo "  Suite '$SUITE_NAME' exists: ${SUITE_CHECK:-0} rows"
 # RunNextTest triggers BC test execution. The session typically dies during test
 # execution (test isolation), so we ignore the exit code and read results from SQL.
 timeout "${TIMEOUT_MIN}m" dotnet run --project "$TESTRUNNER_DIR" --no-build -c Release -- \
-    --host "$BC_HOST" --company "$COMPANY" --suite "$SUITE_NAME" --timeout "$TIMEOUT_MIN" 2>&1 || true
+    --host "$BC_HOST" --company "$COMPANY" --suite "$SUITE_NAME" --timeout "$TIMEOUT_MIN" \
+    --max-iterations $(( ${CU_COUNT:-100} + 2 )) 2>&1 || true
 
 sleep 2
 

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -54,7 +54,7 @@ async Task<int> RunTests()
     var tokenCapture = new MetadataTokenCapture();
 
     // Initial connection — used only for ClearTestResults before the loop.
-    var (rpc, ws) = await Connect(authBytes, tokenCapture, cts.Token);
+    var (rpc, ws, _) = await Connect(authBytes, tokenCapture, cts.Token);
     var formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
     if (formState == null) return 1;
 
@@ -83,9 +83,10 @@ async Task<int> RunTests()
     for (int iteration = 0; iteration < maxIterations; iteration++)
     {
         // Proactive reconnect before each RunNextTest.
+        CancellationTokenSource sessionEndedCts;
         try
         {
-            (rpc, ws) = await Connect(authBytes, tokenCapture, cts.Token);
+            (rpc, ws, sessionEndedCts) = await Connect(authBytes, tokenCapture, cts.Token);
             formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
             if (formState == null)
             {
@@ -102,8 +103,13 @@ async Task<int> RunTests()
         string testResultJson = "";
         try
         {
-            var actionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
-            actionCts.CancelAfter(TimeSpan.FromMinutes(5));
+            // Link to both the overall timeout and the per-session "session ended" signal.
+            // BC sends ClearClientMetadataCache immediately before killing the WebSocket
+            // session for test isolation.  When we receive it we cancel actionCts, which
+            // aborts the in-flight RunNextTest call without waiting for a TCP-level close
+            // that may never arrive.
+            var actionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, sessionEndedCts.Token);
+            actionCts.CancelAfter(TimeSpan.FromMinutes(3)); // hard fallback if notification never fires
 
             var result = await Invoke(rpc, formState, "RunNextTest", actionCts.Token);
             if (result?["DataSetState"] != null) formState = result["DataSetState"];
@@ -230,21 +236,22 @@ async Task<JToken?> Invoke(JsonRpc rpc, JToken? formState, string action, Cancel
         }, ct);
 }
 
-async Task<(JsonRpc, ClientWebSocket)> Connect(byte[] authBytes, MetadataTokenCapture tc, CancellationToken ct)
+async Task<(JsonRpc, ClientWebSocket, CancellationTokenSource)> Connect(byte[] authBytes, MetadataTokenCapture tc, CancellationToken ct)
 {
     Console.WriteLine($"Connecting to ws://{host}/ws/connect");
+    var sessionEndedCts = new CancellationTokenSource();
     var ws = new ClientWebSocket();
     ws.Options.SetRequestHeader("Authorization", $"Basic {Convert.ToBase64String(authBytes)}");
     await ws.ConnectAsync(new Uri($"ws://{host}/ws/connect"), ct);
     var rpc = new JsonRpc(new WebSocketMessageHandler(ws));
     rpc.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.Verbose;
     rpc.TraceSource.Listeners.Add(tc);
-    rpc.AddLocalRpcTarget(new Callbacks());
+    rpc.AddLocalRpcTarget(new Callbacks(sessionEndedCts));
     rpc.StartListening();
     await rpc.InvokeWithCancellationAsync<JToken>("OpenConnection",
         new object[] { new { LCID = 1033, DefaultLCID = 1033, TimeZoneId = "UTC", Credentials = new { UserName = user, Password = password } } }, ct);
     Console.WriteLine("Connected.");
-    return (rpc, ws);
+    return (rpc, ws, sessionEndedCts);
 }
 
 async Task<JToken?> OpenTestPage(JsonRpc rpc, MetadataTokenCapture tc, string company, CancellationToken ct)
@@ -267,13 +274,21 @@ async Task<JToken?> OpenTestPage(JsonRpc rpc, MetadataTokenCapture tc, string co
 
 class Callbacks
 {
+    private readonly CancellationTokenSource _sessionEndedCts;
+
+    public Callbacks(CancellationTokenSource sessionEndedCts) => _sessionEndedCts = sessionEndedCts;
+
+    // BC sends ClearClientMetadataCache (and sometimes OnSessionTerminating) right before
+    // killing the WebSocket session during test isolation.  We use these as a cancellation
+    // signal so the in-flight RunNextTest Invoke doesn't hang until TCP-level timeout.
+    [JsonRpcMethod("ClearClientMetadataCache")] public Task ClearClientMetadataCache() { _sessionEndedCts.Cancel(); return Task.CompletedTask; }
+    [JsonRpcMethod("OnSessionTerminating")]     public Task OnSessionTerminating()      { _sessionEndedCts.Cancel(); return Task.CompletedTask; }
+
     [JsonRpcMethod("Confirm")] public Task Confirm(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("ProcessServerRequests")] public Task ProcessServerRequests(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("FormRunModal")] public Task FormRunModal(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("FormClose")] public Task FormClose(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("FormActivate")] public Task FormActivate(JToken r) => Task.CompletedTask;
-    [JsonRpcMethod("OnSessionTerminating")] public Task OnSessionTerminating() => Task.CompletedTask;
-    [JsonRpcMethod("ClearClientMetadataCache")] public Task ClearClientMetadataCache() => Task.CompletedTask;
     [JsonRpcMethod("SelectionMenu")] public Task SelectionMenu(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("FileActionDialog")] public Task FileActionDialog(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("FeedbackRequested")] public Task FeedbackRequested(JToken r) => Task.CompletedTask;

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -27,6 +27,7 @@ var company = "CRONUS International Ltd.";
 var user = "admin";
 var password = "Admin123!";
 var timeoutMin = 30;
+var codeunitTimeoutMin = 10; // max time for a single RunNextTest call (per codeunit)
 var suiteName = "DEFAULT";
 var maxIterations = 500;
 
@@ -37,6 +38,7 @@ for (int i = 0; i < args.Length; i++)
     else if (args[i] == "--user" && i + 1 < args.Length) user = args[++i];
     else if (args[i] == "--password" && i + 1 < args.Length) password = args[++i];
     else if (args[i] == "--timeout" && i + 1 < args.Length) timeoutMin = int.Parse(args[++i]);
+    else if (args[i] == "--codeunit-timeout" && i + 1 < args.Length) codeunitTimeoutMin = int.Parse(args[++i]);
     else if (args[i] == "--suite" && i + 1 < args.Length) suiteName = args[++i];
     else if (args[i] == "--max-iterations" && i + 1 < args.Length) maxIterations = int.Parse(args[++i]);
     else if (!args[i].StartsWith("--")) host = args[i];
@@ -115,9 +117,9 @@ async Task<int> RunTests()
             // disarm the watchdog before it could fire.
             var capturedRpc = rpc;
             var capturedWs = ws;
-            _ = Task.Delay(TimeSpan.FromSeconds(180)).ContinueWith(_ =>
+            _ = Task.Delay(TimeSpan.FromMinutes(codeunitTimeoutMin)).ContinueWith(_ =>
             {
-                Console.Error.WriteLine("  Watchdog: aborting hung connection after 3 min");
+                Console.Error.WriteLine($"  Watchdog: aborting hung connection after {codeunitTimeoutMin} min (--codeunit-timeout)");
                 try { capturedWs.Abort(); } catch { }
                 try { capturedRpc.Dispose(); } catch { }
             });

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -124,10 +124,20 @@ async Task<int> RunTests()
 
         try { rpc.Dispose(); ws.Dispose(); } catch { }
 
-        if (string.IsNullOrEmpty(testResultJson) || testResultJson == "All tests executed.")
+        if (testResultJson == "All tests executed.")
         {
             Console.WriteLine("All tests executed.");
             break;
+        }
+
+        // Empty means the connection died after RunNextTest returned but before
+        // GetPage could read the result.  The codeunit results are already
+        // committed to the Test Method Line table.  Continue so the next
+        // iteration reconnects and advances to the next codeunit.
+        if (string.IsNullOrEmpty(testResultJson))
+        {
+            Console.Error.WriteLine("  TestResultJson empty (connection dropped after run) — continuing");
+            continue;
         }
 
         try

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -11,16 +11,16 @@ using StreamJsonRpc;
 // BC Test Runner — connects via WebSocket client services to page 130455
 // (Command Line Test Tool) and runs tests using RunNextTest + TestResultJson.
 //
-// Mirrors BcContainerHelper's Run-TestsInBcContainer external behavior:
-//   1. Open page 130455
-//   2. ClearTestResults
-//   3. RunNextTest loop → parse TestResultJson
-//   4. Output per-method results
+// Mirrors BcContainerHelper's Run-TestsInBcContainer external behavior with
+// renewClientContextBetweenTests: reconnect BEFORE each RunNextTest call so
+// that BC's test-isolation session kill (which drops the WebSocket after each
+// codeunit) is never treated as an error.  BC tracks test-suite progress in
+// the Test Method Line table, so a fresh session always picks up where it
+// left off.
 //
 // Note: The DEFAULT test suite must be pre-created (via SQL in run-tests.sh).
 // The suite is opened by filtering TableView to Name=suiteName, which positions
 // the page on the correct record so OnOpenPage sets CurrentSuiteName correctly.
-// interface matches BcContainerHelper's behavior.
 
 var host = "localhost:7085";
 var company = "CRONUS International Ltd.";
@@ -28,6 +28,7 @@ var user = "admin";
 var password = "Admin123!";
 var timeoutMin = 30;
 var suiteName = "DEFAULT";
+var maxIterations = 500;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -37,6 +38,7 @@ for (int i = 0; i < args.Length; i++)
     else if (args[i] == "--password" && i + 1 < args.Length) password = args[++i];
     else if (args[i] == "--timeout" && i + 1 < args.Length) timeoutMin = int.Parse(args[++i]);
     else if (args[i] == "--suite" && i + 1 < args.Length) suiteName = args[++i];
+    else if (args[i] == "--max-iterations" && i + 1 < args.Length) maxIterations = int.Parse(args[++i]);
     else if (!args[i].StartsWith("--")) host = args[i];
 }
 
@@ -51,24 +53,12 @@ async Task<int> RunTests()
     var cts = new CancellationTokenSource(TimeSpan.FromMinutes(timeoutMin));
     var tokenCapture = new MetadataTokenCapture();
 
+    // Initial connection — used only for ClearTestResults before the loop.
     var (rpc, ws) = await Connect(authBytes, tokenCapture, cts.Token);
     var formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
     if (formState == null) return 1;
 
-    // Read the suite name that page 130455 auto-selected/created
-    Console.Write("Reading page state... ");
-    try
-    {
-        var pg = await rpc.InvokeWithCancellationAsync<JToken>("GetPage",
-            new object[] { new { PageSize = 50, IncludeMoreDataInformation = true, IncludeNonRowData = true }, formState! }, cts.Token);
-        if (pg?["State"] != null) formState = pg["State"];
-        // Log the CurrentSuiteName from NonRowData
-        var pageStr = pg?.ToString() ?? "";
-        Console.WriteLine("OK");
-    }
-    catch (Exception ex) { Console.Error.WriteLine($"warning: {ex.Message[..Math.Min(80, ex.Message.Length)]}"); }
-
-    // ClearTestResults
+    // ClearTestResults once, before the loop.
     Console.Write("Clearing previous results... ");
     try
     {
@@ -78,14 +68,38 @@ async Task<int> RunTests()
     }
     catch (Exception ex) { Console.Error.WriteLine($"warning: {ex.Message[..Math.Min(80, ex.Message.Length)]}"); }
 
-    // RunNextTest loop
+    rpc.Dispose(); ws.Dispose();
+
+    // RunNextTest loop — reconnect BEFORE every call (mirrors BcContainerHelper's
+    // renewClientContextBetweenTests).  Each test-codeunit run will kill the BC
+    // session (test isolation), so ConnectionLostException is the normal outcome.
+    // BC tracks which codeunit to run next in the Test Method Line table, so a
+    // fresh session always advances to the next pending codeunit.
     int totalPassed = 0, totalFailed = 0, totalSkipped = 0;
     var allResults = new List<JObject>();
     var startTime = DateTime.UtcNow;
 
     Console.WriteLine("\n=== Running Tests ===");
-    while (true)
+    for (int iteration = 0; iteration < maxIterations; iteration++)
     {
+        // Proactive reconnect before each RunNextTest.
+        try
+        {
+            (rpc, ws) = await Connect(authBytes, tokenCapture, cts.Token);
+            formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
+            if (formState == null)
+            {
+                Console.Error.WriteLine("  Could not open test page after reconnect");
+                break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"  Reconnect failed: {ex.Message[..Math.Min(80, ex.Message.Length)]}");
+            break;
+        }
+
+        string testResultJson = "";
         try
         {
             var actionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
@@ -94,35 +108,37 @@ async Task<int> RunTests()
             var result = await Invoke(rpc, formState, "RunNextTest", actionCts.Token);
             if (result?["DataSetState"] != null) formState = result["DataSetState"];
 
-            // Read TestResultJson via GetPage
-            var testResultJson = await ReadTestResultJson(rpc, formState!, cts.Token);
-            if (string.IsNullOrEmpty(testResultJson) || testResultJson == "All tests executed.")
-            {
-                Console.WriteLine("All tests executed.");
-                break;
-            }
-            var parsed = JObject.Parse(testResultJson);
-            allResults.Add(parsed);
-            ProcessResult(parsed, ref totalPassed, ref totalFailed, ref totalSkipped);
+            // Try to read result while the connection is still alive.
+            testResultJson = await ReadTestResultJson(rpc, formState!, cts.Token);
         }
-        catch (RemoteInvocationException ex) when (ex.Message.Contains("All tests executed"))
+        catch (Exception ex) when (ex is ConnectionLostException || ex is RemoteInvocationException || ex is OperationCanceledException)
+        {
+            // Expected: BC killed the session after the codeunit finished (test isolation).
+            // The result is committed to the Test Method Line table; the next iteration
+            // will reconnect and RunNextTest will advance to the next codeunit.
+            Console.Error.WriteLine($"  Session ended after codeunit (expected): {ex.Message[..Math.Min(60, ex.Message.Length)]}");
+            try { rpc.Dispose(); ws.Dispose(); } catch { }
+            await Task.Delay(500, CancellationToken.None);
+            continue;
+        }
+
+        try { rpc.Dispose(); ws.Dispose(); } catch { }
+
+        if (string.IsNullOrEmpty(testResultJson) || testResultJson == "All tests executed.")
         {
             Console.WriteLine("All tests executed.");
             break;
         }
-        catch (Exception ex) when (ex is RemoteInvocationException || ex is OperationCanceledException || ex is ConnectionLostException)
+
+        try
         {
-            Console.Error.WriteLine($"  Session ended: {ex.Message[..Math.Min(80, ex.Message.Length)]}");
-            try
-            {
-                rpc.Dispose(); ws.Dispose();
-                await Task.Delay(2000, cts.Token);
-                (rpc, ws) = await Connect(authBytes, tokenCapture, cts.Token);
-                formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
-                if (formState == null) break;
-                Console.WriteLine("  Reconnected, continuing...");
-            }
-            catch { Console.Error.WriteLine("  Reconnect failed"); break; }
+            var parsed = JObject.Parse(testResultJson);
+            allResults.Add(parsed);
+            ProcessResult(parsed, ref totalPassed, ref totalFailed, ref totalSkipped);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"  Could not parse result JSON: {ex.Message[..Math.Min(80, ex.Message.Length)]}");
         }
     }
 
@@ -153,8 +169,6 @@ async Task<int> RunTests()
     int total = totalPassed + totalFailed + totalSkipped;
     Console.WriteLine($"\nResults: {total} total, {totalPassed} passed, {totalFailed} failed, {totalSkipped} skipped");
 
-    try { await rpc.InvokeAsync("CloseConnection"); } catch { }
-    rpc.Dispose(); ws.Dispose();
     return totalFailed > 0 ? 1 : (totalPassed > 0 ? 0 : 1);
 }
 

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -104,31 +104,25 @@ async Task<int> RunTests()
         try
         {
             // BC kills the AL session after each test-codeunit run (test isolation).
-            // It does NOT always send a clean WebSocket close frame, so StreamJsonRpc's
-            // cancellation pathway (which tries to send $/cancelRequest over the dead TCP)
-            // also hangs.
+            // It does NOT send a clean WebSocket close frame, so the pending Invoke hangs
+            // indefinitely.  We use a watchdog task that aborts the WebSocket after a
+            // deadline — this interrupts the StreamJsonRpc receive loop and causes
+            // ConnectionLostException to be thrown on the pending InvokeWithCancellationAsync.
             //
-            // Solution: a watchdog Task directly disposes the JsonRpc object after
-            // a deadline.  JsonRpc.Dispose() immediately throws ConnectionLostException
-            // on all pending calls, regardless of the network state.
-            //
-            // The ClearClientMetadataCache / OnSessionTerminating callbacks (which also
-            // cancel sessionEndedCts) serve as a fast path when BC does send those
-            // notifications; the watchdog is the reliable fallback.
+            // IMPORTANT: we do NOT link the watchdog to sessionEndedCts.  BC sends
+            // ClearClientMetadataCache for reasons other than session termination (e.g.
+            // after app publish), which would immediately cancel a linked token and silently
+            // disarm the watchdog before it could fire.
             var capturedRpc = rpc;
-            using var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, sessionEndedCts.Token);
-            _ = Task.Delay(TimeSpan.FromSeconds(180), watchdogCts.Token).ContinueWith(
-                _ =>
-                {
-                    Console.Error.WriteLine("  Watchdog: RunNextTest timeout — force-disposing connection");
-                    try { capturedRpc.Dispose(); } catch { }
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.NotOnCanceled,
-                TaskScheduler.Default);
+            var capturedWs = ws;
+            _ = Task.Delay(TimeSpan.FromSeconds(180)).ContinueWith(_ =>
+            {
+                Console.Error.WriteLine("  Watchdog: aborting hung connection after 3 min");
+                try { capturedWs.Abort(); } catch { }
+                try { capturedRpc.Dispose(); } catch { }
+            });
 
             var result = await Invoke(rpc, formState, "RunNextTest", cts.Token);
-            watchdogCts.Cancel(); // session completed normally; disarm watchdog
             if (result?["DataSetState"] != null) formState = result["DataSetState"];
 
             // Try to read result while the connection is still alive.
@@ -296,10 +290,11 @@ class Callbacks
     public Callbacks(CancellationTokenSource sessionEndedCts) => _sessionEndedCts = sessionEndedCts;
 
     // BC sends ClearClientMetadataCache (and sometimes OnSessionTerminating) right before
-    // killing the WebSocket session during test isolation.  We use these as a cancellation
-    // signal so the in-flight RunNextTest Invoke doesn't hang until TCP-level timeout.
-    [JsonRpcMethod("ClearClientMetadataCache")] public Task ClearClientMetadataCache() { _sessionEndedCts.Cancel(); return Task.CompletedTask; }
-    [JsonRpcMethod("OnSessionTerminating")]     public Task OnSessionTerminating()      { _sessionEndedCts.Cancel(); return Task.CompletedTask; }
+    // killing the WebSocket session during test isolation.  We log receipt for diagnostics.
+    // NOTE: BC also sends ClearClientMetadataCache for other reasons (e.g. app publish),
+    // so receiving it does NOT reliably mean the session is ending.
+    [JsonRpcMethod("ClearClientMetadataCache")] public Task ClearClientMetadataCache() { Console.Error.WriteLine("  [notification] ClearClientMetadataCache received"); _sessionEndedCts.Cancel(); return Task.CompletedTask; }
+    [JsonRpcMethod("OnSessionTerminating")]     public Task OnSessionTerminating()      { Console.Error.WriteLine("  [notification] OnSessionTerminating received"); _sessionEndedCts.Cancel(); return Task.CompletedTask; }
 
     [JsonRpcMethod("Confirm")] public Task Confirm(JToken r) => Task.CompletedTask;
     [JsonRpcMethod("ProcessServerRequests")] public Task ProcessServerRequests(JToken r) => Task.CompletedTask;

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -103,15 +103,32 @@ async Task<int> RunTests()
         string testResultJson = "";
         try
         {
-            // Link to both the overall timeout and the per-session "session ended" signal.
-            // BC sends ClearClientMetadataCache immediately before killing the WebSocket
-            // session for test isolation.  When we receive it we cancel actionCts, which
-            // aborts the in-flight RunNextTest call without waiting for a TCP-level close
-            // that may never arrive.
-            var actionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, sessionEndedCts.Token);
-            actionCts.CancelAfter(TimeSpan.FromMinutes(3)); // hard fallback if notification never fires
+            // BC kills the AL session after each test-codeunit run (test isolation).
+            // It does NOT always send a clean WebSocket close frame, so StreamJsonRpc's
+            // cancellation pathway (which tries to send $/cancelRequest over the dead TCP)
+            // also hangs.
+            //
+            // Solution: a watchdog Task directly disposes the JsonRpc object after
+            // a deadline.  JsonRpc.Dispose() immediately throws ConnectionLostException
+            // on all pending calls, regardless of the network state.
+            //
+            // The ClearClientMetadataCache / OnSessionTerminating callbacks (which also
+            // cancel sessionEndedCts) serve as a fast path when BC does send those
+            // notifications; the watchdog is the reliable fallback.
+            var capturedRpc = rpc;
+            using var watchdogCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, sessionEndedCts.Token);
+            _ = Task.Delay(TimeSpan.FromSeconds(180), watchdogCts.Token).ContinueWith(
+                _ =>
+                {
+                    Console.Error.WriteLine("  Watchdog: RunNextTest timeout — force-disposing connection");
+                    try { capturedRpc.Dispose(); } catch { }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.NotOnCanceled,
+                TaskScheduler.Default);
 
-            var result = await Invoke(rpc, formState, "RunNextTest", actionCts.Token);
+            var result = await Invoke(rpc, formState, "RunNextTest", cts.Token);
+            watchdogCts.Cancel(); // session completed normally; disarm watchdog
             if (result?["DataSetState"] != null) formState = result["DataSetState"];
 
             // Try to read result while the connection is still alive.


### PR DESCRIPTION
Fixes #2

## Root cause

BC's test isolation spawns a child AL sub-process per test codeunit. When that sub-process finishes, it terminates the parent WebSocket session — before the `InvokeApplicationMethod("RunNextTest")` response is sent. The previous code caught `ConnectionLostException` reactively and reconnected, but because BC hadn't committed the result to the `Test Method Line` table before killing the connection, `RunNextTest` always re-ran the same codeunit. Infinite loop.

## Fix

This mirrors BcContainerHelper's `renewClientContextBetweenTests` pattern exactly: **reconnect BEFORE every `RunNextTest` call**, not after an error.

BC tracks suite progress in the `Test Method Line` table (via the test runner codeunit). A fresh session always opens the page positioned on the next pending codeunit, so `RunNextTest` advances correctly. `ConnectionLostException` is now treated as the normal, expected outcome of a codeunit run under test isolation.

### `tools/TestRunner/Program.cs`

- Proactive reconnect (`Connect` + `OpenTestPage`) at the **top** of every loop iteration
- `ClearTestResults` runs **once** before the loop (not on every reconnect)
- `ConnectionLostException` / `RemoteInvocationException` caught inside the loop: log + `continue` (no reconnect inside catch)
- `ReadTestResultJson` is still attempted after `RunNextTest` returns for inline progress output; if the connection dropped, the final SQL query in `run-tests.sh` captures the authoritative results
- Added `--max-iterations N` CLI arg (default 500) as a safety exit

### `scripts/run-tests.sh`

- Passes `--max-iterations $((CU_COUNT + 2))` to `TestRunner`