### PR TITLE
perf: cache Docker image at GHCR and BC artifacts between CI runs

### DIFF
--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -13,6 +13,10 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -28,8 +32,35 @@ jobs:
         JSON=$(echo "$VERSIONS" | python3 -c "import sys,json; print(json.dumps({'bc_version': sys.stdin.read().strip().split(',')}))")
         echo "matrix=$JSON" >> $GITHUB_OUTPUT
 
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push BC runner image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: src/Dockerfile
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}/bc-runner:${{ github.sha }}
+          ghcr.io/${{ github.repository }}/bc-runner:latest
+        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/bc-runner:cache
+        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/bc-runner:cache,mode=max
+
   test:
-    needs: prepare
+    needs: [prepare, build-image]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -39,6 +70,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cache BC artifacts
+      id: artifact-cache
+      uses: actions/cache@v4
+      with:
+        path: ./artifact-cache/${{ matrix.bc_version }}
+        key: bc-artifacts-${{ matrix.bc_version }}-${{ hashFiles('scripts/download-artifacts.sh') }}
+        restore-keys: |
+          bc-artifacts-${{ matrix.bc_version }}-
+
+    - name: Download BC artifacts
+      if: steps.artifact-cache.outputs.cache-hit != 'true'
+      env:
+        BC_VERSION: ${{ matrix.bc_version }}
+      run: |
+        mkdir -p ./artifact-cache/$BC_VERSION
+        scripts/download-artifacts.sh sandbox "$BC_VERSION" w1 ./artifact-cache/$BC_VERSION
 
     - name: Setup .NET SDK and AL compiler
       uses: actions/setup-dotnet@v4
@@ -51,12 +106,14 @@ jobs:
           --version 16.2.28.57946 2>/dev/null || true
         echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
 
-    - name: Build and start BC
+    - name: Start BC
       env:
         BC_VERSION: ${{ matrix.bc_version }}
+        BC_ARTIFACTS_DIR: ${{ github.workspace }}/artifact-cache/${{ matrix.bc_version }}
+        BC_RUNNER_IMAGE: ghcr.io/${{ github.repository }}/bc-runner:${{ github.sha }}
       run: |
         STEP_START=$(date +%s)
-        docker compose up -d --build 2>&1 | tail -10
+        docker compose up -d 2>&1 | tail -10
 
         echo "Waiting for BC to be healthy..."
         for i in $(seq 1 360); do

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -305,3 +305,76 @@ jobs:
         echo "=== BC v$BC_VERSION ==="
         echo "Build + start: ${BUILD_DURATION:-n/a}s"
         docker compose logs bc 2>&1 | grep "\[entrypoint\]" | tail -5
+
+  # Exercises the container's own artifact download path (no pre-cached artifacts).
+  # This verifies the feature works and lets us measure in-container download speed
+  # directly so it can be compared against the host-side download used by test jobs.
+  # Runs once (BC 27.5) in parallel with the main matrix.
+  test-container-download:
+    needs: [build-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Container download test (BC 27.5)
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set lowercase image name
+      run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')/bc-runner" >> $GITHUB_ENV
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Start BC (in-container artifact download)
+      # BC_ARTIFACTS_DIR is intentionally NOT set so docker-compose uses a named
+      # volume (bc-artifacts) which starts empty — forcing the entrypoint to
+      # download artifacts itself.  This validates the container download feature.
+      env:
+        BC_VERSION: "27.5"
+        BC_RUNNER_IMAGE: ${{ env.IMAGE }}:${{ github.sha }}
+      run: |
+        STEP_START=$(date +%s)
+        docker compose up -d 2>&1 | tail -10
+
+        echo "Waiting for BC to be healthy (in-container download included in this time)..."
+        for i in $(seq 1 360); do
+          STATUS=$(docker inspect --format='{{.State.Health.Status}}' $(docker compose ps -q bc) 2>/dev/null || echo "unknown")
+          case "$STATUS" in
+            healthy)
+              echo "BC healthy after $((i*5))s (including in-container artifact download)"
+              break
+              ;;
+            unhealthy)
+              echo "ERROR: BC container unhealthy"
+              docker compose logs bc 2>&1 | tail -50
+              exit 1
+              ;;
+          esac
+          if ! docker compose ps bc 2>/dev/null | grep -q "Up"; then
+            echo "ERROR: BC container died"
+            docker compose logs bc 2>&1 | tail -50
+            exit 1
+          fi
+          [ $((i % 12)) -eq 0 ] && echo "  $((i*5))s: $(docker compose logs bc 2>&1 | grep '\[entrypoint\]' | tail -1)"
+          sleep 5
+        done
+
+        if [ "$STATUS" != "healthy" ]; then
+          echo "ERROR: BC did not become healthy within 30 minutes"
+          docker compose logs bc 2>&1 | tail -100
+          exit 1
+        fi
+
+        echo "TOTAL_DURATION=$(($(date +%s) - STEP_START))" >> $GITHUB_ENV
+
+    - name: Download timing summary
+      if: always()
+      run: |
+        echo "=== In-container artifact download timing ==="
+        docker compose logs bc 2>&1 | grep "\[artifacts\]"
+        echo ""
+        echo "Total start time (download + DB restore + BC startup): ${TOTAL_DURATION:-n/a}s"

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set lowercase image name
+      run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')/bc-runner" >> $GITHUB_ENV
+
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
@@ -54,10 +57,10 @@ jobs:
         file: src/Dockerfile
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}/bc-runner:${{ github.sha }}
-          ghcr.io/${{ github.repository }}/bc-runner:latest
-        cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/bc-runner:cache
-        cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/bc-runner:cache,mode=max
+          ${{ env.IMAGE }}:${{ github.sha }}
+          ${{ env.IMAGE }}:latest
+        cache-from: type=registry,ref=${{ env.IMAGE }}:cache
+        cache-to: type=registry,ref=${{ env.IMAGE }}:cache,mode=max
 
   test:
     needs: [prepare, build-image]
@@ -70,6 +73,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Set lowercase image name
+      run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')/bc-runner" >> $GITHUB_ENV
 
     - name: Log in to GHCR
       uses: docker/login-action@v3
@@ -110,7 +116,7 @@ jobs:
       env:
         BC_VERSION: ${{ matrix.bc_version }}
         BC_ARTIFACTS_DIR: ${{ github.workspace }}/artifact-cache/${{ matrix.bc_version }}
-        BC_RUNNER_IMAGE: ghcr.io/${{ github.repository }}/bc-runner:${{ github.sha }}
+        BC_RUNNER_IMAGE: ${{ env.IMAGE }}:${{ github.sha }}
       run: |
         STEP_START=$(date +%s)
         docker compose up -d 2>&1 | tail -10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "${SQL_PORT:-11433}:1433"
     volumes:
-      - bc-artifacts:/bc/artifacts:ro
+      - ${BC_ARTIFACTS_DIR:-bc-artifacts}:/bc/artifacts:ro
     healthcheck:
       test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${SA_PASSWORD:-Passw0rd123!}' -C -No -Q "SELECT 1" || exit 1
       interval: 10s
@@ -16,6 +16,7 @@ services:
       start_period: 20s
 
   bc:
+    image: ${BC_RUNNER_IMAGE:-bc-runner:local}
     build:
       context: .
       dockerfile: src/Dockerfile
@@ -37,7 +38,7 @@ services:
       BC_CLEAR_ALL_APPS: ${BC_CLEAR_ALL_APPS:-false}
       SQL_SERVER: sql
     volumes:
-      - bc-artifacts:/bc/artifacts
+      - ${BC_ARTIFACTS_DIR:-bc-artifacts}:/bc/artifacts
       - bc-service:/bc/service
     healthcheck:
       test: test -f /tmp/bc-ready && curl -sf -o /dev/null -u admin:Admin123! http://localhost:7048/BC/ODataV4/Company || exit 1

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -2,10 +2,20 @@
 # Download BC artifacts (platform + country) to a target directory.
 # Supports both public and insider artifact URLs.
 #
+# Performance design:
+#   - App and platform zips are downloaded IN PARALLEL to a fast temp dir
+#     (host tmpfs / runner /tmp) rather than directly to the destination
+#     volume.  This avoids writing the raw zip into the (slower) Docker
+#     named volume and cuts the effective I/O to the volume by ~50%.
+#   - Timing is logged for each phase so you can see exactly where time
+#     goes: version resolution, download, and extraction.
+#
 # Usage:
 #   With full URL:  download-artifacts.sh <url> <dest>
 #   With parts:     download-artifacts.sh <type> <version> <country> <dest>
 set -e
+
+_ms() { date +%s%3N; }
 
 # Parse arguments: either (url, dest) or (type, version, country, dest)
 if [ $# -eq 2 ]; then
@@ -21,6 +31,7 @@ elif [ $# -eq 4 ]; then
     # by listing available blobs in the Azure CDN storage container
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
+        T_RESOLVE=$(_ms)
         RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
             grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
         if [ -z "$RESOLVED" ]; then
@@ -30,7 +41,7 @@ elif [ $# -eq 4 ]; then
                 grep -oP '<Name>\K[^<]+' | head -10
             exit 1
         fi
-        echo "[artifacts] Resolved: $BC_VERSION → $RESOLVED"
+        echo "[artifacts] Resolved: $BC_VERSION → $RESOLVED ($(( $(_ms) - T_RESOLVE ))ms)"
         BC_VERSION="$RESOLVED"
     fi
 
@@ -42,31 +53,53 @@ else
     exit 1
 fi
 
-echo "[artifacts] App URL: $APP_URL"
+echo "[artifacts] App URL:      $APP_URL"
 echo "[artifacts] Platform URL: $PLATFORM_URL"
 
-# Download and extract app artifact
-mkdir -p "$DEST/app"
-echo "[artifacts] Downloading app artifact..."
-curl -sSL "$APP_URL" -o "$DEST/bc-app.zip"
-echo "[artifacts] Extracting app ($(du -h "$DEST/bc-app.zip" | cut -f1))..."
-unzip -qo "$DEST/bc-app.zip" -d "$DEST/app"
-rm -f "$DEST/bc-app.zip"
+# Download zips to a temp dir (host /tmp is fast tmpfs/SSD, not a Docker volume).
+# This avoids writing ~1-3 GB of zip data into the destination volume just to
+# immediately delete them after extraction — halving the volume write load.
+TMPDIR_DL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_DL"' EXIT
 
-# Read platform version from manifest
+mkdir -p "$DEST/app" "$DEST/platform"
+
+# ── Parallel download ──────────────────────────────────────────────────────
+echo "[artifacts] Downloading app + platform in parallel..."
+T0=$(_ms)
+curl -sSL --retry 3 "$APP_URL"      -o "$TMPDIR_DL/app.zip"      &
+APP_PID=$!
+curl -sSL --retry 3 "$PLATFORM_URL" -o "$TMPDIR_DL/platform.zip" &
+PLATFORM_PID=$!
+
+wait $APP_PID      || { echo "[artifacts] ERROR: app artifact download failed";      exit 1; }
+wait $PLATFORM_PID || { echo "[artifacts] ERROR: platform artifact download failed"; exit 1; }
+
+T_DOWNLOADED=$(_ms)
+APP_BYTES=$(stat -c%s "$TMPDIR_DL/app.zip")
+PLAT_BYTES=$(stat -c%s "$TMPDIR_DL/platform.zip")
+TOTAL_MB=$(( (APP_BYTES + PLAT_BYTES) / 1024 / 1024 ))
+DOWNLOAD_MS=$(( T_DOWNLOADED - T0 ))
+# Avoid divide-by-zero if somehow instantaneous
+SPEED_MBS=$(( DOWNLOAD_MS > 0 ? TOTAL_MB * 1000 / DOWNLOAD_MS : 0 ))
+echo "[artifacts] Downloaded: app=$(du -h "$TMPDIR_DL/app.zip" | cut -f1) platform=$(du -h "$TMPDIR_DL/platform.zip" | cut -f1) in ${DOWNLOAD_MS}ms (~${SPEED_MBS} MB/s)"
+
+# ── Extract ────────────────────────────────────────────────────────────────
+echo "[artifacts] Extracting app..."
+T_EXTRACT=$(_ms)
+unzip -qo "$TMPDIR_DL/app.zip" -d "$DEST/app"
+
 PLATFORM_VERSION=$(python3 -c "import json; print(json.load(open('$DEST/app/manifest.json'))['platform'])" 2>/dev/null)
 echo "[artifacts] Platform version: $PLATFORM_VERSION"
 
-# Download and extract platform artifact
-mkdir -p "$DEST/platform"
-echo "[artifacts] Downloading platform artifact..."
-curl -sSL "$PLATFORM_URL" -o "$DEST/bc-platform.zip"
-ZIPSIZE=$(du -h "$DEST/bc-platform.zip" | cut -f1)
-echo "[artifacts] Extracting platform ($ZIPSIZE)..."
-# Extract ServiceTier, ModernDev, test framework apps, and test assemblies
-unzip -qo "$DEST/bc-platform.zip" 'ServiceTier/*' 'ModernDev/*' 'applications/*' 'Test Assemblies/*' -d "$DEST/platform" 2>/dev/null || \
-unzip -qo "$DEST/bc-platform.zip" -d "$DEST/platform"
-rm -f "$DEST/bc-platform.zip"
-echo "[artifacts] Disk usage: $(du -sh "$DEST" | cut -f1)"
+echo "[artifacts] Extracting platform (ServiceTier, ModernDev, applications, Test Assemblies)..."
+# Selective extraction keeps only what the service tier needs (~50% of the zip)
+unzip -qo "$TMPDIR_DL/platform.zip" 'ServiceTier/*' 'ModernDev/*' 'applications/*' 'Test Assemblies/*' -d "$DEST/platform" 2>/dev/null || \
+    unzip -qo "$TMPDIR_DL/platform.zip" -d "$DEST/platform"
+
+T_DONE=$(_ms)
+EXTRACT_MS=$(( T_DONE - T_EXTRACT ))
+TOTAL_MS=$(( T_DONE - T0 ))
+echo "[artifacts] Extracted in ${EXTRACT_MS}ms | Total: ${TOTAL_MS}ms | Disk: $(du -sh "$DEST" | cut -f1)"
 
 echo "[artifacts] Done. Artifacts at $DEST"


### PR DESCRIPTION
Closes #4

## What

Two independent optimisations that together should reduce the ~7–22 min "Build and start BC" step to **under 2 min on cache hits**.

### 1. Docker image cached at GHCR (`build-image` job)

A new `build-image` job runs once per commit and pushes the BC runner image to `ghcr.io/<repo>/bc-runner:<sha>` using `docker/build-push-action` with `cache-from/cache-to type=registry`. All 6 matrix `test` jobs then **pull** the pre-built image instead of each rebuilding it from scratch. Eliminates the per-job Docker build overhead.

### 2. BC artifacts cached with `actions/cache`

Before `docker compose up`, each `test` job:
1. Checks `actions/cache` for key `bc-artifacts-<version>-<hash(download script)>`
2. On a **cache miss**: runs `scripts/download-artifacts.sh` to fetch the BC platform + app zips from Azure CDN into `./artifact-cache/<version>/`
3. Sets `BC_ARTIFACTS_DIR` so Docker Compose bind-mounts the pre-downloaded artifacts into both the `bc` and `sql` containers

The entrypoint already short-circuits when `manifest.json` is present (line 37), so no entrypoint changes were needed.

### `docker-compose.yml` changes

| | Before | After |
|---|---|---|
| `bc` artifacts volume | `bc-artifacts:/bc/artifacts` (named volume, always empty on new runners) | `${BC_ARTIFACTS_DIR:-bc-artifacts}:/bc/artifacts` (bind mount when env var is set) |
| `sql` artifacts volume | same | same pattern |
| `bc` image | (none — always built) | `${BC_RUNNER_IMAGE:-bc-runner:local}` — pre-pulled image in CI; local dev still uses `build:` |

**Local dev is unchanged**: no env vars set → named volumes + `docker compose up --build` as before.

## Expected impact

| Optimisation | Savings (first run) | Savings (cache hit) |
|---|---|---|
| GHCR image cache | ~1–2 min per job | ~1–2 min per job |
| BC artifact cache | 0 (first run downloads) | **5–20 min per job** |

On the second and subsequent runs, the 6 BC versions should each take **~2–4 min** (CRONUS DB restore + BC JIT startup) instead of the current 7–25 min.