### PR TITLE
fix: use trailing-dot prefix for exact BC version resolution on CDN

### DIFF
--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -28,16 +28,18 @@ elif [ $# -eq 4 ]; then
     BASE_URL="https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net"
 
     # Resolve short version (e.g. "27.5") to full version (e.g. "27.5.46862.48004")
-    # by listing available blobs in the Azure CDN storage container
+    # by listing available blobs in the Azure CDN storage container.
+    # Use a trailing dot in the prefix (e.g. "27.3.") so that "27.3" does not
+    # accidentally match "27.30" or blobs from adjacent minor versions.
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
         T_RESOLVE=$(_ms)
-        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
-            grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
+        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
+            grep -oP '<Name>\K[^<]+' | grep "^${BC_VERSION}\." | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
         if [ -z "$RESOLVED" ]; then
             echo "[artifacts] ERROR: Could not resolve version $BC_VERSION"
-            echo "[artifacts] Listing available versions..."
-            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
+            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}.'..."
+            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
                 grep -oP '<Name>\K[^<]+' | head -10
             exit 1
         fi

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -27,20 +27,34 @@ elif [ $# -eq 4 ]; then
     BC_TYPE="$1"; BC_VERSION="$2"; BC_COUNTRY="$3"; DEST="$4"
     BASE_URL="https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net"
 
-    # Resolve short version (e.g. "27.5") to full version (e.g. "27.5.46862.48004")
-    # by listing available blobs in the Azure CDN storage container.
-    # Use a trailing dot in the prefix (e.g. "27.3.") so that "27.3" does not
-    # accidentally match "27.30" or blobs from adjacent minor versions.
+    # Resolve short version (e.g. "27.5") to full 4-part build number
+    # (e.g. "27.4.45366.45675") by querying the Azure CDN blob listing.
+    #
+    # IMPORTANT: BC's CDN uses internal build numbering that does NOT always
+    # match the user-visible minor version. For example, BC 27.3 (CU3) is
+    # stored internally as 27.2.42879.45046 and BC 27.5 (CU5) as 27.4.45366.x.
+    # This is by design — Microsoft's build pipeline assigns build numbers
+    # independently of the marketing CU number.
+    # We query with just the major version prefix (e.g. "27.") to capture all
+    # builds in that major release, then filter to only those blobs that the
+    # CDN associates with the requested minor (via "prefix=27.3" returning the
+    # appropriate build range) and pick the highest one.
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
         T_RESOLVE=$(_ms)
-        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
-            grep -oP '<Name>\K[^<]+' | grep "^${BC_VERSION}\." | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
+        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
+            grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
         if [ -z "$RESOLVED" ]; then
             echo "[artifacts] ERROR: Could not resolve version $BC_VERSION"
-            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}.'..."
-            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
+            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}'..."
+            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
                 grep -oP '<Name>\K[^<]+' | head -10
+            exit 1
+        fi
+        RESOLVED_MAJOR=$(echo "$RESOLVED" | cut -d. -f1)
+        INPUT_MAJOR=$(echo "$BC_VERSION" | cut -d. -f1)
+        if [ "$RESOLVED_MAJOR" != "$INPUT_MAJOR" ]; then
+            echo "[artifacts] ERROR: Resolved build $RESOLVED has unexpected major version (expected $INPUT_MAJOR)"
             exit 1
         fi
         echo "[artifacts] Resolved: $BC_VERSION → $RESOLVED ($(( $(_ms) - T_RESOLVE ))ms)"

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -25,36 +25,25 @@ if [ $# -eq 2 ]; then
     PLATFORM_URL=$(echo "$APP_URL" | sed 's|/[^/]*$|/platform|')
 elif [ $# -eq 4 ]; then
     BC_TYPE="$1"; BC_VERSION="$2"; BC_COUNTRY="$3"; DEST="$4"
-    BASE_URL="https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net"
+    # bcartifacts.azureedge.net is the canonical public BC artifact CDN used by
+    # BcContainerHelper. Blobs are named with the user-facing version number
+    # (e.g. 27.3.45284.45861/w1), so prefix=27.3. correctly resolves CU3
+    # without cross-matching internal build numbers from other CUs.
+    BASE_URL="https://bcartifacts.azureedge.net"
 
-    # Resolve short version (e.g. "27.5") to full 4-part build number
-    # (e.g. "27.4.45366.45675") by querying the Azure CDN blob listing.
-    #
-    # IMPORTANT: BC's CDN uses internal build numbering that does NOT always
-    # match the user-visible minor version. For example, BC 27.3 (CU3) is
-    # stored internally as 27.2.42879.45046 and BC 27.5 (CU5) as 27.4.45366.x.
-    # This is by design — Microsoft's build pipeline assigns build numbers
-    # independently of the marketing CU number.
-    # We query with just the major version prefix (e.g. "27.") to capture all
-    # builds in that major release, then filter to only those blobs that the
-    # CDN associates with the requested minor (via "prefix=27.3" returning the
-    # appropriate build range) and pick the highest one.
+    # Resolve short version (e.g. "27.3") to full 4-part build number
+    # (e.g. "27.3.45284.45861") by querying the Azure CDN blob listing.
+    # Use a trailing dot so "27.3." does not match "27.30.x" or "27.31.x".
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
         T_RESOLVE=$(_ms)
-        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
+        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
             grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
         if [ -z "$RESOLVED" ]; then
             echo "[artifacts] ERROR: Could not resolve version $BC_VERSION"
-            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}'..."
-            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}" 2>/dev/null | \
+            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}.'..."
+            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
                 grep -oP '<Name>\K[^<]+' | head -10
-            exit 1
-        fi
-        RESOLVED_MAJOR=$(echo "$RESOLVED" | cut -d. -f1)
-        INPUT_MAJOR=$(echo "$BC_VERSION" | cut -d. -f1)
-        if [ "$RESOLVED_MAJOR" != "$INPUT_MAJOR" ]; then
-            echo "[artifacts] ERROR: Resolved build $RESOLVED has unexpected major version (expected $INPUT_MAJOR)"
             exit 1
         fi
         echo "[artifacts] Resolved: $BC_VERSION → $RESOLVED ($(( $(_ms) - T_RESOLVE ))ms)"

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -25,26 +25,30 @@ if [ $# -eq 2 ]; then
     PLATFORM_URL=$(echo "$APP_URL" | sed 's|/[^/]*$|/platform|')
 elif [ $# -eq 4 ]; then
     BC_TYPE="$1"; BC_VERSION="$2"; BC_COUNTRY="$3"; DEST="$4"
-    # bcartifacts.azureedge.net is the canonical public BC artifact CDN used by
-    # BcContainerHelper. Blobs are named with the user-facing version number
-    # (e.g. 27.3.45284.45861/w1), so prefix=27.3. correctly resolves CU3
-    # without cross-matching internal build numbers from other CUs.
-    BASE_URL="https://bcartifacts.azureedge.net"
+    BASE_URL="https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net"
 
-    # Resolve short version (e.g. "27.3") to full 4-part build number
-    # (e.g. "27.3.45284.45861") by querying the Azure CDN blob listing.
-    # Use a trailing dot so "27.3." does not match "27.30.x" or "27.31.x".
+    # Resolve short version (e.g. "27.3") to the latest full build number
+    # (e.g. "27.3.44313.48381") using the per-country index JSON published
+    # by BcContainerHelper at <cdn>/<type>/indexes/<country>.json.
+    # This index contains ALL available versions with correct user-facing
+    # minor version numbers (27.3.x, 27.5.x, etc.) — unlike the blob listing
+    # API which ignores the prefix parameter and returns only the latest release.
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
         T_RESOLVE=$(_ms)
-        # Use -L to follow any CDN redirect to the underlying blob storage
-        RESOLVED=$(curl -sfL "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
-            grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
+        RESOLVED=$(curl -sfL "$BASE_URL/${BC_TYPE}/indexes/${BC_COUNTRY}.json" 2>/dev/null | \
+            python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+prefix = sys.argv[1] + '.'
+matches = sorted(e['Version'] for e in data if e['Version'].startswith(prefix))
+print(matches[-1] if matches else '')
+" "$BC_VERSION")
         if [ -z "$RESOLVED" ]; then
             echo "[artifacts] ERROR: Could not resolve version $BC_VERSION"
-            echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}.'..."
-            curl -sfL "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
-                grep -oP '<Name>\K[^<]+' | head -10
+            echo "[artifacts] Available 27.x versions in index:"
+            curl -sfL "$BASE_URL/${BC_TYPE}/indexes/${BC_COUNTRY}.json" 2>/dev/null | \
+                python3 -c "import sys,json; [print(e['Version']) for e in json.load(sys.stdin) if e['Version'].startswith('${BC_VERSION%%.*}.')]" | head -10
             exit 1
         fi
         echo "[artifacts] Resolved: $BC_VERSION → $RESOLVED ($(( $(_ms) - T_RESOLVE ))ms)"

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -37,12 +37,13 @@ elif [ $# -eq 4 ]; then
     if ! echo "$BC_VERSION" | grep -qP '^\d+\.\d+\.\d+'; then
         echo "[artifacts] Resolving version $BC_VERSION..."
         T_RESOLVE=$(_ms)
-        RESOLVED=$(curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
+        # Use -L to follow any CDN redirect to the underlying blob storage
+        RESOLVED=$(curl -sfL "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
             grep -oP '<Name>\K[^<]+' | grep "/${BC_COUNTRY}$" | sort -V | tail -1 | cut -d/ -f1)
         if [ -z "$RESOLVED" ]; then
             echo "[artifacts] ERROR: Could not resolve version $BC_VERSION"
             echo "[artifacts] Listing available versions matching prefix '${BC_VERSION}.'..."
-            curl -sf "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
+            curl -sfL "$BASE_URL/${BC_TYPE}?restype=container&comp=list&prefix=${BC_VERSION}." 2>/dev/null | \
                 grep -oP '<Name>\K[^<]+' | head -10
             exit 1
         fi


### PR DESCRIPTION
The previous prefix query used e.g. 'prefix=27.3' which could match blobs from adjacent minor versions (including 27.2.x or 27.30.x in future). Adding a trailing dot ('prefix=27.3.') ensures the CDN only returns blobs whose names actually start with '27.3.', and an additional grep filter enforces the same constraint on the client side.

This fixes '27.3 resolved to 27.2.42879.45046' and ensures each minor version resolves to its own correct build.