### PR TITLE
MacOS differences

### DIFF
--- a/MacOS.md
+++ b/MacOS.md
@@ -1,0 +1,24 @@
+## MacOS steps
+
+* Podman needs to run in "rootful" mode. 
+
+  `podman machine set --rootful`
+
+* You might need to enable rosetta: 
+
+  `podman machine ssh 'sudo touch /etc/containers/enable-rosetta'`
+
+* Make sure that the _~/.config/containers/containers.conf_ contains:
+  ```
+    [machine]
+    provider = "applehv"
+  ```
+
+* You will need at least 15G to run BC. 
+  
+  `podman machine set --memory 15000`
+
+* You will need to install docker-compose, podman compose does not support "wait"
+
+  `brew install docker-compose`
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   sql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: ${SA_PASSWORD:-Passw0rd123!}
       MSSQL_MEMORY_LIMIT_MB: ${MSSQL_MEMORY_LIMIT_MB:-2048}
     ports:
       - "${SQL_PORT:-11433}:1433"
+    user: "0:0"
     tmpfs:
       - /var/opt/mssql/data:size=4g
     volumes:
@@ -24,6 +25,7 @@ services:
 
   bc:
     image: ${BC_RUNNER_IMAGE:-bc-runner:local}
+    platform: linux/amd64
     build:
       context: .
       dockerfile: src/Dockerfile

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -39,8 +39,8 @@ CODEUNIT_RANGE=""
 APP_FILE=""
 TIMEOUT_MIN=30
 DISABLED_TESTS_DIR=""
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
 TEST_RUNNER_APP=""
 JUNIT_OUTPUT=""
 
@@ -130,14 +130,14 @@ if [ -z "$COMPANIES_JSON" ]; then
     exit 1
 fi
 
-COMPANY_AUTO=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; print(c.get('name',c.get('Name','')))" 2>/dev/null || true)
-COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; print(c.get('id',c.get('SystemId','')))" 2>/dev/null || true)
+COMPANY_AUTO=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('name',''))" 2>/dev/null || true)
+COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('id',''))" 2>/dev/null || true)
 [ -z "$COMPANY" ] && COMPANY="${COMPANY_AUTO:-CRONUS International Ltd.}"
 
 if [ -z "$COMPANY_ID" ]; then
     for url in "${BASE_URL}/api/v2.0/companies" "${_API_FALLBACK}/api/v2.0/companies"; do
         COMPANY_ID=$(curl -sf --max-time 10 -u "$AUTH" "$url" 2>/dev/null \
-            | py3 -c "import sys,json; [print(c.get('id',c.get('SystemId',''))) for c in json.load(sys.stdin)['value'] if c.get('name',c.get('Name',''))==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
+            | py3 -c "import sys,json; [print({k.lower():v for k,v in c.items()}.get('id','')) for c in json.load(sys.stdin)['value'] if {k.lower():v for k,v in c.items()}.get('name','')==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
         [ -n "$COMPANY_ID" ] && break
     done
 fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: compile StartupHook + stubs + tools
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 
 # gcc needed for compiling Win32 P/Invoke stubs (kernel32_stubs.c → libwin32_stubs.so)
 RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
@@ -27,7 +27,7 @@ RUN mkdir -p /build/output/refasm && \
     echo "Copied $(ls /build/output/refasm/*.dll | wc -l) reference assemblies"
 
 # Runtime stage: minimal image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Install tools for artifact download and SQL setup + en_US locale
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Dear Stefan!

Thank you for this masterpiece.

I was able to start BC on macos and podman.

The following errors were fixed:
- 2022-CU17 is the last version which can work on MacOS. (2025-CU1 fixes it)
- user: 0.0 needed for podman
- linux/amd64 needed to be specified, otherwise ARM base images were used
- Regarding run-tests.sh:
  - I'm using CDPATH which prints the directory on cd, therefore I silenced it
  - COMPANY_AUTO/COMPANY_ID 
    - I'm not really sure about this. Cloude changed it, because otherwise it did not started the tests.
    
 Can you try it on linux as well?