### PR TITLE
macOS (Apple Silicon + podman) support

### DIFF
--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -208,3 +208,68 @@ jobs:
         docker compose logs bc 2>&1 | grep "\[artifacts\]"
         echo ""
         echo "Total start time (download + DB restore + BC startup): ${TOTAL_DURATION:-n/a}s"
+
+  # Exercises the macOS compose overlay (docker-compose.macos.yml) on a
+  # Linux runner. GitHub-hosted macOS runners cannot run containers at
+  # all — Apple's Virtualization framework forbids nested virtualization
+  # on the M1/M2 hardware GitHub uses — so the podman/Rosetta side of
+  # MacOS.md is untestable in hosted CI. This leg verifies everything
+  # else the overlay changes: the 2022-CU17 image tag still exists on
+  # MCR, SQL Server boots and restores the demo DB while running as
+  # root (user 0:0), and BC comes up healthy on top of that SQL.
+  # COMPOSE_FILE makes every docker compose invocation (including the
+  # shared wait-for-bc-healthy.sh) apply the overlay consistently.
+  test-macos-overlay:
+    needs: [build-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: macOS overlay test (BC 28.1)
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker-compose.macos.yml
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set lowercase image name
+      run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')/bc-runner" >> $GITHUB_ENV
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Validate compose files merge
+      run: |
+        # Catches YAML/merge errors in the overlay without booting anything,
+        # and proves the overlay actually overrides what it claims to.
+        MERGED=$(docker compose config)
+        echo "$MERGED" | grep -q "mssql/server:2022-CU17-ubuntu-22.04" \
+          || { echo "ERROR: overlay did not apply the CU17 SQL image pin"; exit 1; }
+        echo "$MERGED" | grep -q 'user: "0:0"' \
+          || { echo "ERROR: overlay did not apply user 0:0 on the sql service"; exit 1; }
+
+    - name: Start BC with macOS overlay
+      env:
+        BC_VERSION: "28.1"
+        BC_RUNNER_IMAGE: ${{ needs.build-image.outputs.runner_image }}
+      run: |
+        docker compose up -d 2>&1 | tail -10
+        ./scripts/wait-for-bc-healthy.sh 30
+
+    - name: Verify overlay applied to running stack
+      run: |
+        SQL_CID=$(docker compose ps -q sql)
+        SQL_IMAGE=$(docker inspect --format '{{.Config.Image}}' "$SQL_CID")
+        SQL_UID=$(docker compose exec -T sql id -u)
+        echo "sql image: $SQL_IMAGE, uid: $SQL_UID"
+        [ "$SQL_IMAGE" = "mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04" ] \
+          || { echo "ERROR: sql container is not running the CU17 image"; exit 1; }
+        [ "$SQL_UID" = "0" ] \
+          || { echo "ERROR: sql container is not running as root"; exit 1; }
+
+    - name: SQL log excerpt
+      if: failure()
+      run: docker compose logs sql 2>&1 | tail -50
+

--- a/MacOS.md
+++ b/MacOS.md
@@ -22,3 +22,17 @@
 
   `brew install docker-compose`
 
+## Starting BC
+
+Use the macOS overlay on top of the main compose file. It pins SQL Server
+to 2022-CU17 (later 2022 CUs crash under Rosetta emulation) and runs the
+SQL container as root (rootful podman mounts the data tmpfs root-owned,
+which the image's non-root mssql user cannot write to):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d --wait
+```
+
+Everything else (ports, env vars like `BC_VERSION`/`BC_COUNTRY`, running
+tests via `scripts/run-tests.sh`) works the same as on Linux.
+

--- a/MacOS.md
+++ b/MacOS.md
@@ -1,0 +1,24 @@
+## MacOS steps
+
+* Podman needs to run in "rootful" mode. 
+
+  `podman machine set --rootful`
+
+* You might need to enable rosetta: 
+
+  `podman machine ssh 'sudo touch /etc/containers/enable-rosetta'`
+
+* Make sure that the _~/.config/containers/containers.conf_ contains:
+  ```
+    [machine]
+    provider = "applehv"
+  ```
+
+* You will need at least 15G to run BC. 
+  
+  `podman machine set --memory 15000`
+
+* You will need to install docker-compose, podman compose does not support "wait"
+
+  `brew install docker-compose`
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Just to start BC and run AL tests:
 - ~4 GB RAM (2 GB SQL + 1-2 GB BC)
 - ~3 GB disk for artifacts (downloaded once, cached in Docker volumes)
 
+Running on an Apple Silicon Mac (podman + Rosetta)? See [MacOS.md](MacOS.md)
+for the extra setup steps and the `docker-compose.macos.yml` overlay.
+
 That's it — **no .NET SDK on the host is required**. The WebSocket test
 runner used by `run-tests.sh` is bundled inside the bc-runner image and
 invoked via `docker compose exec`, so all the .NET work happens in the

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,17 @@
+# macOS (Apple Silicon + podman) overrides — see MacOS.md for full setup steps.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d --wait
+#
+# These settings are needed only when running under Rosetta emulation on
+# Apple Silicon; applying them on Linux would pin SQL to an old CU and run
+# it as root for no reason, so they live in this overlay instead of the
+# main compose file.
+services:
+  sql:
+    # SQL Server 2022 CU18+ crashes under Rosetta 2 emulation; CU17 is the
+    # last 2022 CU that works on Apple Silicon (SQL Server 2025 fixes it).
+    image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
+    # Rootful podman mounts the tmpfs at /var/opt/mssql/data owned by root,
+    # which the image's non-root mssql user cannot write to.
+    user: "0:0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
   sql:
-    image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: ${SA_PASSWORD:-Passw0rd123!}
       MSSQL_MEMORY_LIMIT_MB: ${MSSQL_MEMORY_LIMIT_MB:-2048}
     ports:
       - "${SQL_PORT:-11433}:1433"
-    user: "0:0"
     tmpfs:
       - /var/opt/mssql/data:size=4g
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   sql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU17-ubuntu-22.04
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: ${SA_PASSWORD:-Passw0rd123!}
       MSSQL_MEMORY_LIMIT_MB: ${MSSQL_MEMORY_LIMIT_MB:-2048}
     ports:
       - "${SQL_PORT:-11433}:1433"
+    user: "0:0"
     tmpfs:
       - /var/opt/mssql/data:size=4g
     volumes:
@@ -24,6 +25,7 @@ services:
 
   bc:
     image: ${BC_RUNNER_IMAGE:-bc-runner:local}
+    platform: linux/amd64
     build:
       context: .
       dockerfile: src/Dockerfile

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -39,8 +39,8 @@ CODEUNIT_RANGE=""
 APP_FILE=""
 TIMEOUT_MIN=30
 DISABLED_TESTS_DIR=""
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
 TEST_RUNNER_APP=""
 JUNIT_OUTPUT=""
 
@@ -130,14 +130,14 @@ if [ -z "$COMPANIES_JSON" ]; then
     exit 1
 fi
 
-COMPANY_AUTO=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; print(c.get('name',c.get('Name','')))" 2>/dev/null || true)
-COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; print(c.get('id',c.get('SystemId','')))" 2>/dev/null || true)
+COMPANY_AUTO=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('name',''))" 2>/dev/null || true)
+COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('id',''))" 2>/dev/null || true)
 [ -z "$COMPANY" ] && COMPANY="${COMPANY_AUTO:-CRONUS International Ltd.}"
 
 if [ -z "$COMPANY_ID" ]; then
     for url in "${BASE_URL}/api/v2.0/companies" "${_API_FALLBACK}/api/v2.0/companies"; do
         COMPANY_ID=$(curl -sf --max-time 10 -u "$AUTH" "$url" 2>/dev/null \
-            | py3 -c "import sys,json; [print(c.get('id',c.get('SystemId',''))) for c in json.load(sys.stdin)['value'] if c.get('name',c.get('Name',''))==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
+            | py3 -c "import sys,json; [print({k.lower():v for k,v in c.items()}.get('id','')) for c in json.load(sys.stdin)['value'] if {k.lower():v for k,v in c.items()}.get('name','')==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
         [ -n "$COMPANY_ID" ] && break
     done
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -30,6 +30,9 @@
 
 set -uo pipefail
 
+# CDPATH makes cd print the resolved directory, which corrupts $(cd ... && pwd)
+unset CDPATH
+
 # === Configuration & CLI Parsing ===
 BASE_URL="http://localhost:7048/BC"
 DEV_URL="http://localhost:7049/BC/dev"
@@ -39,8 +42,8 @@ CODEUNIT_RANGE=""
 APP_FILE=""
 TIMEOUT_MIN=30
 DISABLED_TESTS_DIR=""
-SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_RUNNER_APP=""
 JUNIT_OUTPUT=""
 
@@ -131,13 +134,13 @@ if [ -z "$COMPANIES_JSON" ]; then
 fi
 
 COMPANY_AUTO=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('name',''))" 2>/dev/null || true)
-COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('id',''))" 2>/dev/null || true)
+COMPANY_ID=$(echo "$COMPANIES_JSON" | py3 -c "import sys,json; c=json.load(sys.stdin)['value'][0]; m={k.lower():v for k,v in c.items()}; print(m.get('id',m.get('systemid','')))" 2>/dev/null || true)
 [ -z "$COMPANY" ] && COMPANY="${COMPANY_AUTO:-CRONUS International Ltd.}"
 
 if [ -z "$COMPANY_ID" ]; then
     for url in "${BASE_URL}/api/v2.0/companies" "${_API_FALLBACK}/api/v2.0/companies"; do
         COMPANY_ID=$(curl -sf --max-time 10 -u "$AUTH" "$url" 2>/dev/null \
-            | py3 -c "import sys,json; [print({k.lower():v for k,v in c.items()}.get('id','')) for c in json.load(sys.stdin)['value'] if {k.lower():v for k,v in c.items()}.get('name','')==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
+            | py3 -c "import sys,json; ms=[{k.lower():v for k,v in c.items()} for c in json.load(sys.stdin)['value']]; [print(m.get('id',m.get('systemid',''))) for m in ms if m.get('name','')==sys.argv[1]]" "$COMPANY" 2>/dev/null || true)
         [ -n "$COMPANY_ID" ] && break
     done
 fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: compile StartupHook + stubs + tools
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 
 # gcc needed for compiling Win32 P/Invoke stubs (kernel32_stubs.c → libwin32_stubs.so)
 RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
@@ -27,7 +27,7 @@ RUN mkdir -p /build/output/refasm && \
     echo "Copied $(ls /build/output/refasm/*.dll | wc -l) reference assemblies"
 
 # Runtime stage: minimal image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Install tools for artifact download and SQL setup + en_US locale
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Rebased and hardened version of #9 by @smil2k (original commits preserved with authorship), plus fixes from code review.

## From #9 (@smil2k)

- `MacOS.md` with podman setup steps for Apple Silicon (rootful mode, Rosetta, applehv provider, memory sizing, docker-compose via brew)
- `platform: linux/amd64` on the `bc` service and in `src/Dockerfile` (no-op on amd64 hosts, forces emulation on ARM Macs)
- Case-insensitive company name/id matching in `run-tests.sh`
- CDPATH workaround in `run-tests.sh`

## Review fixes on top

- **Restored the `SystemId` fallback** in the `run-tests.sh` company lookup — the case-insensitive rewrite dropped it, which broke the `/ODataV4/Company` fallback path (that entity exposes `SystemId`, not `id`). Both lookups now use `id` → `systemid`.
- **Moved the macOS-only SQL tweaks into a new `docker-compose.macos.yml` overlay** instead of changing defaults for everyone:
  - SQL image pin `2022-CU17-ubuntu-22.04` (CU18+ crashes under Rosetta; Linux keeps `2022-latest`)
  - `user: "0:0"` (rootful podman mounts the data tmpfs root-owned; Linux keeps the image's non-root mssql user)
  - Usage: `docker compose -f docker-compose.yml -f docker-compose.macos.yml up -d --wait`
- Replaced the `cd` output redirects with a single `unset CDPATH` so genuine `cd` failures stay visible
- Documented the overlay in `MacOS.md` and linked it from the README requirements section

## Validation

- `bash -n` on `run-tests.sh`; company-id one-liners tested against api/v2.0 (`id`), OData (`SystemId`), and multi-company shapes
- `docker compose config` verified: base file alone is identical to today's Linux behavior; with the overlay, the CU17 pin and root user apply

Supersedes #9.

https://claude.ai/code/session_01TWHy8xdAzK3SxE5paVyUoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWHy8xdAzK3SxE5paVyUoc)_