### PR TITLE
AL debugging on Linux: attach + launch (F5) working

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ printing, and file upload are untested. Details: [docs/WEBCLIENT-POC.md](docs/WE
    extension uses the `launch.json` settings to publish via the dev
    endpoint and open the configured startup page.
 
+5. **Debugging works** — breakpoints, call stack, variables, watch,
+   stepping, both `launch` and `attach` (`"request": "attach"` with
+   `"breakOnNext": "WebClient"` pairs nicely with `BC_WEBCLIENT=1` to
+   debug code triggered from the browser). Requires StartupHook Patch
+   #25 (included). Details and verified configs:
+   [docs/DEBUGGING.md](docs/DEBUGGING.md).
+
 ---
 
 ## Command-line workflow

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -160,11 +160,11 @@ fs.writeFileSync("extension.js",s.replace(o,p));console.log("patched OK");'
 ```
 
 Reload the VS Code window afterwards. After the patch, attach completes in
-~1 s and the call stack appears ~3 s after a breakpoint hit. The proper fix
-belongs upstream (microsoft/AL: the adapter should never default its package
-cache to the process CWD, and/or the extension should pass the cache path /
-cwd to the adapter); until then this patch or an equivalent is required on
-Linux.
+~1 s and the call stack appears ~3 s after a breakpoint hit. Reported
+upstream as [microsoft/AL#8276](https://github.com/microsoft/AL/issues/8276)
+(the adapter should never default its package cache to the process CWD,
+and/or the extension should pass the cache path / cwd to the adapter); until
+that's fixed this patch or an equivalent is required on Linux.
 
 ## Capturing VS Code ↔ adapter DAP traffic
 

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,271 @@
+# AL Debugging against the Linux NST
+
+**Status: attach mode AND launch mode (F5) WORKING** (verified 2026-06-12 on
+BC 28.1, AL extension 17.0; both need the one-line VS Code-side extension.js
+patch described below). The attach-debug cycle works
+end-to-end against the Linux service tier: breakpoint set → bind
+(`verified:true`) → hit → call stack → variables (Globals `Rec`/`xRec`, Locals) →
+watch evaluation → step over → continue. Verified through the **web client**
+(`BC_WEBCLIENT=1`): a breakpoint on a Customer List `OnOpenPage` trigger hits
+when the page is opened in the browser, locals update correctly across a step,
+and the browser session resumes cleanly on continue.
+
+**Real VS Code on Linux additionally needs a one-line patch to the AL
+extension's `extension.js`** (see "VS Code hangs on the call stack" below) —
+without it, attach takes 15–30 s and the first breakpoint hit shows "Paused on
+Step" with a call stack that never loads, even though the server side is fine.
+
+## Recommended setup: attach + breakOnNext
+
+```jsonc
+{
+  "name": "Attach to Linux BC",
+  "type": "al",
+  "request": "attach",
+  "server": "http://localhost",
+  "port": 7049,
+  "serverInstance": "BC",
+  "tenant": "default",
+  "authentication": "UserPassword",      // BCRUNNER / Admin123!
+  "environmentType": "OnPrem",
+  "breakOnNext": "WebClient"             // or "WebServiceClient" / "Background"
+}
+```
+
+Workflow: publish with Ctrl+F5 (or `Run without debugging`), start the attach
+configuration, then sign in to the web client at `http://localhost:8080` (a
+*fresh* sign-in creates the new session the debugger attaches to — an
+already-open tab is an old session) and navigate to your page by clicking in
+the UI. Breakpoints hit with full call stack and variables.
+
+**The `server` value should be the NST host with `port` 7049 — NOT the web
+client's `http://localhost:8080`.** The AL extension talks to the dev endpoint
+(7049) for everything (publish, symbols, debugger hub). One subtlety verified
+empirically: the **`port` property overrides any port embedded in the
+`server` URL** — `"server": "http://localhost:8080"` plus `"port": 7049`
+still sends dev requests to 7049, and VS Code's config resolver injects
+`port: 7049` (the schema default) whenever launch.json omits it, so a stray
+`:8080` in `server` is masked in practice. Hand-rolled DAP clients that omit
+`port` get no such rescue: requests go to Kestrel, 404, and the session dies
+with "Not Found". Use `http://localhost` + `7049` and don't rely on the
+masking.
+
+Nothing container-side needs enabling — the dev endpoint (7049) is already
+published and the debugger runs over its SignalR `DebuggerHub`.
+
+## Launch mode (F5): working with the extension.js patch
+
+F5 (`"request": "launch"`) publishes the app, opens the browser at
+`<webEndpoint>?page=N&...&debuggingcontext=<hub-connection-id>`, and relies on
+the web client passing that `debuggingcontext` to the NST when creating the
+session so the session binds to *your* VS Code debug session.
+**User-verified working on 2026-06-12 after applying the extension.js cwd
+patch** (see "VS Code hangs on the call stack" below). Before that patch the
+flow was unreliable: the adapter's multi-second package-cache scan delayed
+the debug session while the browser raced ahead, and attempts died in
+`ConnectionEstablisher.OpenWebSocket → PromptForCredentials()` with
+`NavCancelCredentialPromptException` (visible in `/tmp/webclient.log`),
+landing on the role center unbound. If F5 regresses to that behavior after an
+AL extension update, reapply the patch first.
+
+Infrastructure that IS in place for launch mode:
+
+- **The NST advertises the web client URL.** The entrypoint sets
+  `PublicWebBaseUrl` to `http://localhost:8080/` when `BC_WEBCLIENT=1`
+  (override with `BC_WEBCLIENT_PUBLIC_URL` for remapped ports). Without it the
+  F5 browser URL is the port-less `http://localhost/?page=N` (lands on port
+  80, nothing happens). `GET /BC/dev/metadata` shows the advertised value in
+  `webEndpoint`.
+- **The AL extension caches the web endpoint** in `ServerInfoCache.dat` next
+  to its host binary (`~/.vscode/extensions/ms-dynamics-smb.al-*/bin/linux/`).
+  If F5 keeps opening a port-less URL after the container has the fix, delete
+  that file to force a re-read.
+- **One debug session at a time.** Each F5/attach is its own DebuggerHub
+  connection; a second F5 while an earlier one is alive (or a crashed adapter
+  process lingering — see Things to know) leaves the break to land on the
+  older connection while the new VS Code session shows an empty call stack
+  with "Paused on Step" and no frames.
+
+## What was broken on Linux (and is now fixed)
+
+**StartupHook Patch #25.** Every `setBreakpoints` from VS Code failed with
+*"An unexpected error occurred invoking 'AddBreakpoint' on the server"*. Root
+cause (decompiled from `Microsoft.Dynamics.Nav.Ncl.dll`):
+`DebugRuntimeManager.ExecuteClientCall` evaluates
+
+```csharp
+bool flag2 = debugRuntime.IsDebuggedSessionClosedOrDisposed
+          || (debugRuntime?.DebuggedSession.IsDisposingOrDisposed ?? false);
+```
+
+With `breakOnNext`, breakpoints are set before any session is attached, so
+`DebuggedSession` is null. The `?.` guards `debugRuntime`, **not**
+`DebuggedSession` — the left operand returns `false` for a null session, the
+`||` doesn't short-circuit, and the right operand dereferences null →
+`NullReferenceException` on every hub call. The hook patches
+`BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed` to report `true` for a
+null session, so the expression short-circuits and `ExecuteClientCall` takes
+its safe early-return path. This is a latent upstream bug (same IL on Windows);
+it surfaces in this setup's timing, where breakpoints arrive before the
+debuggee session attaches.
+
+## VS Code hangs on the call stack (extension.js patch required)
+
+**Symptom (real VS Code only — headless DAP harnesses don't hit it):** attach
+takes 15–30 s instead of <1 s, and when a breakpoint hits, VS Code shows
+"Paused on Step" with an empty call stack that never populates. The
+`stackTrace` DAP request never gets a response (observed >3 min with no
+reply). `DebuggerServices.log` (next to the extension's host binary) fills
+with:
+
+```
+An exception happened while reading the package cache: '/home/<user>'.
+Too many levels of symbolic links : '...'
+```
+
+**Root cause (decompiled from
+`Microsoft.Dynamics.Nav.EditorServices.Protocol.dll`,
+`SettingsExtensions.GetPackageCachePaths`):** when the debug adapter has no
+`al.packageCachePath` setting, it falls back to
+`Directory.GetCurrentDirectory()` as the package cache root. The debug
+adapter is a separate process from the language server and **never receives
+workspace settings** — no CLI flag carries `al.packageCachePath` and the
+extension never sends `al/setActiveWorkspace` over the DAP channel — so the
+fallback *always* fires. The extension spawns the adapter via
+`new DebugAdapterExecutable(path, args)` with no `cwd`, so the adapter
+inherits the VS Code extension host's working directory, which on Linux is
+typically `$HOME`. The first `stackTrace` request compiles the project
+(`Workspace.CurrentSolution.GetCompilationAsync`), and that compilation
+recursively scans the entire package cache root for `*.app` files — i.e. all
+of `$HOME`. Any symlink loop under `$HOME` (e.g. mise's
+`~/.local/state/mise/trusted-configs/<id> -> /home/<user>`) makes the scan
+effectively endless. The same scan also runs during `attach` processing,
+which is where the 15–30 s attach delay comes from — and on a slow attach a
+fast sign-in can slip past the `breakOnNext` arm entirely. Windows escapes by
+accident: VS Code's CWD there is a small install directory.
+
+**Fix (must be reapplied after every AL extension update):** make the
+extension spawn the adapter with the workspace folder as CWD, so the fallback
+scans the project directory (where `.alpackages` lives). Idempotent patch:
+
+```bash
+cd ~/.vscode/extensions/ms-dynamics-smb.al-*/dist && cp -n extension.js extension.js.bak-dap-cwd && node -e '
+const fs=require("fs");
+let s=fs.readFileSync("extension.js","utf8");
+const o="const r=yield this.getServerPath();return new a.DebugAdapterExecutable(r,n)";
+const p="const r=yield this.getServerPath();return new a.DebugAdapterExecutable(r,n,{cwd:t.uri.fsPath})";
+if(s.includes(p)){console.log("already patched");process.exit(0);}
+if(s.split(o).length-1!==1){console.error("pattern not found exactly once — extension changed, re-derive the patch");process.exit(1);}
+fs.writeFileSync("extension.js",s.replace(o,p));console.log("patched OK");'
+```
+
+Reload the VS Code window afterwards. After the patch, attach completes in
+~1 s and the call stack appears ~3 s after a breakpoint hit. The proper fix
+belongs upstream (microsoft/AL: the adapter should never default its package
+cache to the process CWD, and/or the extension should pass the cache path /
+cwd to the adapter); until then this patch or an equivalent is required on
+Linux.
+
+## Capturing VS Code ↔ adapter DAP traffic
+
+Two complementary switches, both usable in any AL project:
+
+- `"traceDap": true` in the launch configuration makes the extension attach
+  its `AlDapProtocolMessageLogger`, which logs every DAP message (full JSON)
+  to the AL extension's log output channel at *debug* level. To see it:
+  Command Palette → "Developer: Set Log Level…" → pick the AL channel →
+  Debug. The same content lands in VS Code's extension-host log files on
+  disk.
+- `"al.editorServicesLogLevel": "Verbose"` (workspace settings) makes the
+  spawned host processes log verbosely to `DebuggerServices.log` /
+  `EditorServices.log` next to the host binary
+  (`~/.vscode/extensions/ms-dynamics-smb.al-*/bin/linux/`). This is also
+  where every request error and the package-cache scan exceptions show up,
+  with timestamps — the single most useful file when debugging the debugger.
+
+## Things to know
+
+- **`breakOnNext` attaches to the *next* session.** Navigating the web client
+  by URL (`/?page=22`) opens a *new* session each time, which is *not* the one
+  the debugger attached to. Navigate **inside the UI** (click links/actions) so
+  code runs in the attached session — same as on Windows, just easy to trip
+  over when testing with scripted URL navigation.
+- **Exactly one live debugger connection, please.** Every debug adapter process
+  (`Microsoft.Dynamics.Nav.EditorServices.Host … /startDebugging`) holds its own
+  SignalR connection to the DebuggerHub, and an armed `breakOnNext` on an *older*
+  connection wins the next session. The failure mode looks baffling: the web
+  client freezes on a breakpoint (the session really is paused server-side, and
+  pages opened from other sessions may fail with "an error occurred"), but the
+  VS Code session you're looking at never shows a stop — the break event went to
+  the other connection. If this happens, check for stray adapter processes
+  (`pgrep -af startDebugging`) left behind by crashed debug sessions or headless
+  tooling and kill them, then re-attach.
+- **Stopping the debugger while paused aborts the debugged activity.** If you
+  hit Stop (Shift+F5) while a session is paused inside `OnOpenPage`, the NST
+  throws `NavNCLDebuggerActivityAbortedException` into that activity and the
+  web client shows "An error occurred while opening the page." That's the
+  documented stop semantics, not a Linux bug — refresh the browser and the
+  session continues.
+- **Breakpoints bind on session attach.** The DebuggerHub only registers
+  breakpoints when a debuggee session exists; the AL debug adapter raises the
+  DAP `initialized` event when the session attaches and VS Code (re)sends all
+  breakpoints at that point. This is automatic in VS Code; only hand-rolled
+  DAP clients need to care.
+- **A fresh web-client sign-in attaches the debugger twice.** Sign-in creates
+  a transient session and then the real one ~1 s later; the NST re-attaches
+  the armed debugger connection and the adapter raises `initialized` twice.
+  Harmless: breakpoints are scoped to the debugger connection (verified — a
+  client that arms only on the first `initialized` still hits), and VS Code
+  re-sends breakpoints on every `initialized` anyway. Don't be confused by
+  the doubled events in a DAP trace.
+- **Closing the debugged browser tab ends the VS Code debug session.** When
+  the debugged session dies, the NST calls
+  `OnDetachedFromConnection(terminateSession: true)` and the adapter sends
+  DAP `terminated` ~30 s later — VS Code's debug session just disappears.
+  Expected lifecycle, not a crash; re-attach and sign in again.
+- **Idle SignalR timeout (observed in headless tests, not yet reproduced in
+  VS Code):** a debug connection idling for several minutes occasionally died
+  with *"Server timeout (30000.00ms) elapsed without receiving a message from
+  the server"*, suggesting the NST's hub keep-alive pings stalled. Re-attaching
+  recovers. If this shows up in real VS Code sessions, the NST side
+  (`DebuggerHub` keep-alive on the Kestrel/HttpSys-stub transport) is the place
+  to look.
+- **Credential prompts and caching.** UserPassword credentials are cached in
+  `UserPasswordCache.dat` next to the AL extension's host binary, protected via
+  ASP.NET DataProtection — this works on Linux (verified by decrypting the
+  cache). Two things govern how often VS Code prompts:
+  - The cache key is the literal `server` string + `serverInstance` (lowercased).
+    `"server": "http://localhost"` and `"server": "http://localhost:8080"` are
+    *different entries* even when both end up talking to port 7049 — use one
+    consistent `server` value across all launch/publish configurations or each
+    spelling prompts once.
+  - The cache lives inside the extension's install folder, so every AL extension
+    update wipes it (and the DataProtection key ring is per host *version*), so
+    one re-prompt after an extension update is expected. A server 401 also
+    deletes the entry, but this NST never returns 401 (auth is bypassed), so
+    that path doesn't fire here.
+- **`BC_DEBUG_FIRSTCHANCE=1`** (env var on the `bc` service) prints every
+  thrown exception with its full inner chain to the container log — the NST
+  counterpart to the web client's `WEBCLIENT_DEBUG_FIRSTCHANCE`. This is what
+  surfaced the Patch #25 NRE behind the generic hub error. Very noisy; opt-in
+  only.
+
+## How it was verified headlessly
+
+The AL extension's debug adapter
+(`Microsoft.Dynamics.Nav.EditorServices.Host /startDebugging /projectRoot:<dir>`)
+speaks DAP over stdio and can be driven without VS Code. Two non-obvious
+pieces for anyone repeating this:
+
+- **Credentials**: the adapter reads UserPassword credentials from
+  `UserPasswordCache.dat` next to the host binary (protected via ASP.NET
+  DataProtection, key ring in `~/.config/<EditorServices host assembly name>`).
+  VS Code populates it via the `al/saveUsernamePassword` LSP request after
+  prompting. Headless, the cache can be written by injecting a
+  `DOTNET_STARTUP_HOOKS` assembly into the host process that calls
+  `OnPremiseHttpClientFactory.SaveCredentials` via reflection with the same
+  `LaunchConfiguration` JSON the attach will use (the cache key is derived
+  from server/port/instance/tenant/auth options).
+- **Handshake**: send `setBreakpoints` + `configurationDone` in response to
+  each `initialized` *event* (which arrives at debuggee-attach time), not
+  merely after the `attach` response.

--- a/docs/WEBCLIENT-POC.md
+++ b/docs/WEBCLIENT-POC.md
@@ -37,6 +37,17 @@ docker compose exec bc tail -f /tmp/webclient.log
 The host port is `${BC_WEBCLIENT_PORT:-8080}`. Everything is additive and
 opt-in: with `BC_WEBCLIENT` unset, nothing about the NST boot path changes.
 
+When `BC_WEBCLIENT=1`, the entrypoint also sets the NST's `PublicWebBaseUrl`
+to `http://localhost:${BC_WEBCLIENT_PORT:-8080}/` (override with
+`BC_WEBCLIENT_PUBLIC_URL` when the host-published port differs, e.g. parallel
+instances). This is what the dev endpoint's `webEndpoint` field advertises —
+the AL debugger's launch mode (F5) uses it to open the browser at the right
+URL with the `debuggingcontext` parameter (see `docs/DEBUGGING.md`). Note the
+AL extension caches this in `ServerInfoCache.dat` next to its host binary; if
+F5 keeps opening a port-less `http://localhost/?page=...` URL after enabling
+the web client on an existing setup, delete that file (or restart VS Code's
+AL services) to force a re-read.
+
 ## Architecture
 
 ```
@@ -71,6 +82,7 @@ browser ──HTTP/WS (/csh, JSON-RPC)──▶ Prod.Client.WebCoreApp (Kestrel,
 | `mkdir wwwroot/Resources/ExtractedResources`, `Thumbnails`, `Resources/images/static`, `Reports` | Startup check throws `DirectoryNotFoundException` if missing (the Windows MSI creates them) |
 | Lowercase symlinks in `wwwroot/js/` (`boot.js` → `Boot.js`, …) | The boot view reads script files by lowercased name; Linux is case-sensitive |
 | `wwwroot/Resources/Brand` → `brand` symlink | `BrandProvider` enumerates `Resources/Brand/...`; artifact ships `brand` |
+| `wwwroot/Resources/Fonts` → `fonts` symlink | The FluentUI icon-font CSS requests `Resources/Fonts/fluentui/fabric-icons-*.woff`; artifact ships `fonts`. Without it every glyph icon (action bar, chevrons, system tray) 404s and renders blank |
 | `DOTNET_TieredCompilation=0` | **Critical.** JMP hooks get silently overwritten by Tier-1 recompilation — same invariant as the NST. Symptom was maddening: the EventLog patch worked at startup, then minutes later the original code came back and the first session-level log write killed the session thread |
 | `HTTPSYS_STUB_INJECT_IDENTITY=0` | See stub changes below |
 | `DOTNET_STARTUP_HOOKS=/bc/webclient-hook/WebClientHook.dll` | Replaces the NST hook for this process |
@@ -190,6 +202,31 @@ connections right after `--wait` returns, give it a moment.
 
 ## Known gaps / not validated
 
+- **AL debugger launch mode (F5) session binding is unreliable.** Opening a
+  URL with the `debuggingcontext` query parameter (what F5 generates) forces
+  a re-sign-in, and the web client's session creation then usually dies in
+  `ConnectionEstablisher.OpenWebSocket → PromptForCredentials()` with
+  `NavCancelCredentialPromptException` (logged in `/tmp/webclient.log`), drops
+  the debug parameters, and lands on the role center without binding the
+  debugger. The full cycle (bind → break → stack → variables) was observed
+  working once, so the NST side is fine — the gap is in the web client's
+  credential flow for debug-bound sessions. Attach mode (`breakOnNext`) is
+  unaffected and fully working; see `docs/DEBUGGING.md`.
+- **Record images (Customer/Item/Contact pictures, user avatars) don't
+  render.** The picture control requests
+  `/img?sessionid=...&ts=<mediaGuid>_360x0.` and gets a 404; the
+  `Thumbnails` cache directory stays empty. The serving path
+  (`WebImageHelper.TryLoadMediaThumbnail` →
+  `LogicalMediaProvider.ProvideMediaThumbnail` →
+  `mediaProvider.LoadMediaThumbnail`, then
+  `WebImageHelper.TryGetWebCompatibleImage`) uses **System.Drawing.Common**
+  (`ImageControl.TryLoadImage`, `Image.FromStream`), which throws
+  `PlatformNotSupportedException` unconditionally on Linux in .NET 8 —
+  the web client ships the real Windows-only package. A likely fix is a
+  WebClientHook patch that replaces `TryGetWebCompatibleImage` /
+  `TryLoadImage` with magic-byte content-type sniffing (no actual GDI
+  decode is needed just to serve the bytes), but this is not done yet.
+  Static images (action icons, placeholders, brand assets) are unaffected.
 - `GET /splashCheck` 404s (harmless; splash screen still renders).
 - A stray literal-backslash directory (`wwwroot/Reports\`) appears at
   startup — some path producer outside `FilePersistenceManager` still uses

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -660,6 +660,19 @@ else
     }
 fi
 
+# Advertise the web client URL on the dev endpoint (runs every boot — BC_WEBCLIENT
+# can be toggled on an existing service volume). The AL debugger's launch mode (F5)
+# asks the NST for the web endpoint and opens the browser at
+# "<webEndpoint>?page=N&debuggingcontext=<hub-connection>" — with PublicWebBaseUrl
+# empty the generated URL is the port-less http://localhost/?page=N, which lands on
+# port 80 and the debugger never binds a session. Override the default with
+# BC_WEBCLIENT_PUBLIC_URL when the host port differs (parallel instances).
+if [ "${BC_WEBCLIENT:-0}" = "1" ]; then
+    PUBLIC_WEB_URL="${BC_WEBCLIENT_PUBLIC_URL:-http://localhost:${BC_WEBCLIENT_PORT:-8080}/}"
+    sed -i "s|PublicWebBaseUrl\" value=\"[^\"]*\"|PublicWebBaseUrl\" value=\"$PUBLIC_WEB_URL\"|" "$SERVICE_DIR/CustomSettings.config"
+    log_step "PublicWebBaseUrl set to $PUBLIC_WEB_URL (AL debugger F5 / launch-mode browser URL)"
+fi
+
 log_step "Config check:"
 grep -E "DatabaseServer|DatabaseName|DatabaseUserName|ProtectedDatabase" "$SERVICE_DIR/CustomSettings.config" | head -5
 log_step "Pre-seeding R2R extension DLL cache..."

--- a/scripts/start-webclient.sh
+++ b/scripts/start-webclient.sh
@@ -47,6 +47,10 @@ mkdir -p "$WEBCLIENT_DIR/wwwroot/Resources/ExtractedResources" \
 done)
 # BrandProvider enumerates "Resources/Brand/..." but the artifact ships "brand"
 [ -e "$WEBCLIENT_DIR/wwwroot/Resources/Brand" ] || ln -s brand "$WEBCLIENT_DIR/wwwroot/Resources/Brand"
+# The FluentUI icon-font CSS requests "Resources/Fonts/fluentui/fabric-icons-*.woff"
+# but the artifact ships "Resources/fonts/" — without this every glyph icon in the
+# UI (action bar, chevrons, system tray) is missing.
+[ -e "$WEBCLIENT_DIR/wwwroot/Resources/Fonts" ] || ln -s fonts "$WEBCLIENT_DIR/wwwroot/Resources/Fonts"
 
 # Point the web client at the local NST (NavUserPassword over ws://localhost:7085)
 python3 - "$WEBCLIENT_DIR" "$PORT" <<'PYEOF'

--- a/src/StartupHook/StartupHook.cs
+++ b/src/StartupHook/StartupHook.cs
@@ -73,6 +73,14 @@ using System.Threading.Tasks;
 ///   Fix: hook the canonical id→zone resolver to substitute custom fixed-offset zones
 ///   (same id/names, current UTC offset) for zones that don't survive the round-trip.
 ///
+/// Patch #25: BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed (Nav.Ncl.dll)
+///   AL attach-debugging (breakOnNext) sets breakpoints before a session attaches, so
+///   DebuggedSession is null. DebugRuntimeManager.ExecuteClientCall's null-check guards the
+///   runtime but not the session, so a null DebuggedSession is dereferenced → NullReference,
+///   surfaced to VS Code as "unexpected error invoking 'AddBreakpoint'". Every attach-debug
+///   breakpoint fails. Fix: return true (treat null session as closed/disposed) so the `||`
+///   short-circuits before the bad dereference and ExecuteClientCall takes its safe path.
+///
 /// JMP hooks work ONLY on BC methods (JIT-compiled). BCL methods are ReadyToRun pre-compiled
 /// and cannot be patched this way.
 /// </summary>
@@ -122,6 +130,24 @@ internal class StartupHook
 
 
         Console.WriteLine("[StartupHook] Initializing Linux compatibility patches...");
+
+        // Debug aid (opt-in): BC_DEBUG_FIRSTCHANCE=1 prints every thrown exception
+        // with its full inner chain to stderr. Mirrors WEBCLIENT_DEBUG_FIRSTCHANCE in
+        // the web client hook. Invaluable when a server-side component (e.g. the
+        // SignalR DebuggerHub) swallows the real exception and returns a generic
+        // "unexpected error" to the client. Very noisy — never enable by default.
+        if (Environment.GetEnvironmentVariable("BC_DEBUG_FIRSTCHANCE") == "1")
+        {
+            AppDomain.CurrentDomain.FirstChanceException += (s, e) =>
+            {
+                try
+                {
+                    Console.Error.WriteLine($"[FirstChance] {e.Exception}");
+                }
+                catch { /* never let the logger throw */ }
+            };
+            Console.WriteLine("[StartupHook] BC_DEBUG_FIRSTCHANCE=1: first-chance exception logging enabled");
+        }
 
         // Patch #13 (early): Prevent Watson crash on unobserved task exceptions.
         // Watson's SendReport → GetRegistryValue crashes on Linux (NullRef, no registry).
@@ -329,6 +355,22 @@ internal class StartupHook
         if (name == "Microsoft.Dynamics.Nav.Ncl")
         {
             PatchAssemblyProbing(args.LoadedAssembly);
+        }
+
+        // Patch #25: BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed null-session NRE.
+        //   AL debugging via attach (breakOnNext) sets breakpoints before any session is
+        //   attached, so DebuggedSession is null. DebugRuntimeManager.ExecuteClientCall does:
+        //     flag2 = debugRuntime.IsDebuggedSessionClosedOrDisposed
+        //           || (debugRuntime?.DebuggedSession.IsDisposingOrDisposed ?? false);
+        //   The `?.` guards debugRuntime, NOT DebuggedSession — so a null session makes the
+        //   left operand return false (no short-circuit) and the right operand dereferences
+        //   null → NullReferenceException. The SignalR DebuggerHub wraps it as a generic
+        //   "unexpected error invoking 'AddBreakpoint'", and every attach-debug breakpoint
+        //   fails. Returning true when DebuggedSession is null short-circuits the ||, so
+        //   ExecuteClientCall takes its safe early-return path instead of crashing.
+        if (name == "Microsoft.Dynamics.Nav.Ncl")
+        {
+            PatchDebugRuntimeNullSession(args.LoadedAssembly);
         }
 
         // Patch #16 is now only 16b (NavUser.TryAuthenticate bypass in Nav.Ncl).
@@ -2522,6 +2564,96 @@ internal class StartupHook
         // Intentionally empty — break Microsoft's recursion bug in Nav.OpenXml.
         // No log line per call: this is invoked once per missing image and we don't want
         // to spam logs during legitimate report generation.
+    }
+
+    // ========================================================================
+    // Patch #25: BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed null-session NRE.
+    //
+    // Enables AL attach-debugging (breakOnNext) against the Linux NST. See the
+    // registration comment in OnAssemblyLoad for the full root cause. In short:
+    // DebugRuntimeManager.ExecuteClientCall dereferences a null DebuggedSession
+    // because the original code's `?.` only null-checks the runtime, not the
+    // session. We make the getter report "closed/disposed" (true) for a null
+    // session so the `||` short-circuits before the bad dereference.
+    //
+    // Assembly:  Microsoft.Dynamics.Nav.Ncl.dll
+    // Type:      Microsoft.Dynamics.Nav.Runtime.Debugger.BaseDebugRuntime
+    // Property:  protected internal virtual bool IsDebuggedSessionClosedOrDisposed { get; }
+    //            (single definition on the base; DebugRuntime does not override it)
+    //
+    // Original getter:
+    //     var s = DebuggedSession;
+    //     if (s == null) return false;                 // <-- the bug: should be safe-true
+    //     return s.AccessLock?.IsStoppingOrDisposed == true;
+    // ========================================================================
+    private static MethodInfo? _origIsDebuggedSessionClosed;
+
+    private static void PatchDebugRuntimeNullSession(Assembly navNcl)
+    {
+        if (IsPatchDisabled("25")) return;
+        try
+        {
+            var type = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.Debugger.BaseDebugRuntime");
+            if (type == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #25: BaseDebugRuntime type not found — skipping");
+                return;
+            }
+
+            var getter = type.GetProperty("IsDebuggedSessionClosedOrDisposed",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)?.GetGetMethod(nonPublic: true);
+            if (getter == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #25: IsDebuggedSessionClosedOrDisposed getter not found — skipping");
+                return;
+            }
+
+            _origIsDebuggedSessionClosed = getter;
+            var replacement = typeof(StartupHook).GetMethod(
+                nameof(Replacement_IsDebuggedSessionClosedOrDisposed),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            ApplyJmpHook(getter, replacement, "BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed (Patch #25)");
+            Console.WriteLine("[StartupHook] Patch #25: attach-debug null-session NRE guarded");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #25 failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Replacement for the instance getter BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed.
+    /// Instance method → JMP hook passes the receiver as the first explicit argument.
+    /// Reflection (not a typed cast) avoids a compile-time dependency on the BC assembly.
+    /// Semantics: a null DebuggedSession is treated as "closed/disposed" (true) — the only
+    /// behavioural change from the original, and exactly what stops ExecuteClientCall from
+    /// dereferencing the null session.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Replacement_IsDebuggedSessionClosedOrDisposed(object self)
+    {
+        try
+        {
+            var session = self.GetType().GetProperty("DebuggedSession",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(self);
+            if (session == null)
+                return true; // null session → safe early-return in ExecuteClientCall
+
+            var accessLock = session.GetType().GetProperty("AccessLock",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(session);
+            if (accessLock == null)
+                return false;
+
+            var isStopping = accessLock.GetType().GetProperty("IsStoppingOrDisposed",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(accessLock);
+            return isStopping is bool b && b;
+        }
+        catch
+        {
+            // Any unexpected reflection failure: report "not closed" so we never
+            // introduce a new failure path — the worst case reverts to original risk.
+            return false;
+        }
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Makes AL debugging (VS Code, attach **and** launch mode) work against the Linux NST, verified on BC 28.1 with AL extension 17.0:

- **StartupHook Patch #25** — `BaseDebugRuntime.IsDebuggedSessionClosedOrDisposed` now reports `true` for a null `DebuggedSession`. With `breakOnNext`, breakpoints arrive before any session attaches; Microsoft's `DebugRuntimeManager.ExecuteClientCall` null-guards the runtime but not the session, so every `AddBreakpoint` hub call died with a NullReferenceException (surfaced in VS Code as *"An unexpected error occurred invoking 'AddBreakpoint' on the server"*). Latent upstream bug (same IL on Windows); our timing surfaces it.
- **`BC_DEBUG_FIRSTCHANCE=1`** (opt-in) — first-chance exception logging in the NST; this is what exposed the NRE behind the generic hub error.
- **entrypoint: `PublicWebBaseUrl`** — set automatically when `BC_WEBCLIENT=1` (override: `BC_WEBCLIENT_PUBLIC_URL`) so F5 launch mode opens the browser at a URL with a real port and the session binds to the VS Code debug session.
- **start-webclient: `Fonts` → `fonts` symlink** — fixes missing FluentUI glyph icons in the web client.
- **docs/DEBUGGING.md (new)** — verified attach/launch recipes, DAP-capture how-to (`traceDap`, Verbose host logs), debugger lifecycle notes, and the root cause + one-line client-side fix for the AL debug adapter hang in real VS Code on Linux: the adapter defaults its package cache to the **process CWD** (it never receives `al.packageCachePath`), VS Code spawns it with `cwd=$HOME`, and the recursive `*.app` scan of the home directory makes attach take 15–30 s and leaves `stackTrace` unanswered ("Paused on Step", empty call stack). Patch: spawn the adapter with the workspace folder as CWD. Being reported upstream to microsoft/AL.

## Test plan

- Headless DAP harness (real adapter binary, VS Code-faithful semantics): attach → fresh web-client sign-in → breakpoint hit on `OnOpenPage` → call stack/scopes/variables → continue. Repeated with the adapter spawned `cwd=$HOME` to reproduce the VS Code hang, and `cwd=<project>` to confirm the fix.
- Real VS Code on Linux: attach and F5 launch verified end-to-end after the extension.js patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)