### PR TITLE
Stop concurrent jobs on one machine from deleting each other's BC

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -45,6 +45,33 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      instance_slot:
+        description: >
+          Which BC stack on the machine this job should use. Leave at 0 unless
+          you want two jobs running BC on ONE self-hosted machine at the same
+          time.
+
+          Background: Compose names its project after the working directory's
+          basename — `bc-linux` for every job — and docker-compose.yml binds
+          fixed host ports. So every job on a given docker host addresses the
+          same containers and the same ports, and a second job's
+          `docker compose down` deletes the first job's BC mid-test (issue
+          #24). This workflow therefore takes a machine-wide lease around the
+          container lifecycle: jobs sharing a machine queue rather than
+          destroying each other.
+
+          Raising the slot is how you buy real parallelism instead of queueing.
+          Slot N gets its own compose project (`bc-linux-N`) and its own ports,
+          offset by N*100 — slot 1 puts the dev endpoint on 7149, OData on
+          7148, SQL on 11533, and so on. Two jobs on different slots run
+          concurrently; two on the same slot still queue.
+
+          Budget roughly a full BC service tier plus a SQL Server per slot in
+          RAM before raising it. It has no effect on a GitHub-hosted runner —
+          every job there already has a machine to itself.
+        required: false
+        type: number
+        default: 0
       bc_version:
         description: "BC platform version (e.g. 27.5)"
         required: false
@@ -373,6 +400,25 @@ jobs:
       # asked for BC_TYPE/BC_VERSION/BC_COUNTRY instead and could not recognise
       # its own cache. Blank on every non-insider leg, which is the normal path.
       BC_ARTIFACT_URL: ${{ inputs.bc_artifact_url }}
+      # ─── Which container stack on this machine is ours (issue #24) ───
+      # Slot 0 keeps the historical identity exactly: project `bc-linux`, the
+      # default ports from docker-compose.yml, and therefore the same named
+      # volumes a self-hosted runner has already warmed. Raising the slot moves
+      # the whole stack — project name AND every published port — so two jobs
+      # can hold BC at once on one machine.
+      #
+      # Job-level rather than step-level for the same reason BC_ARTIFACTS_DIR
+      # is: `docker compose`, `wait-for-bc-healthy.sh` and `run-tests.sh`'s
+      # `docker compose exec` all have to agree about which project they are
+      # talking to, and they run in different steps.
+      COMPOSE_PROJECT_NAME: ${{ inputs.instance_slot == 0 && 'bc-linux' || format('bc-linux-{0}', inputs.instance_slot) }}
+      SQL_PORT: ${{ 11433 + inputs.instance_slot * 100 }}
+      BC_DEV_PORT: ${{ 7049 + inputs.instance_slot * 100 }}
+      BC_ODATA_PORT: ${{ 7048 + inputs.instance_slot * 100 }}
+      BC_API_PORT: ${{ 7052 + inputs.instance_slot * 100 }}
+      BC_MGMT_PORT: ${{ 7045 + inputs.instance_slot * 100 }}
+      BC_CLIENT_PORT: ${{ 7085 + inputs.instance_slot * 100 }}
+      BC_WEBCLIENT_PORT: ${{ 8080 + inputs.instance_slot * 100 }}
 
     steps:
       # ─── Phase 1: cheap parallel-friendly checkouts ──────────────────
@@ -512,6 +558,28 @@ jobs:
           echo "BC_LICENSE_HOST_PATH=$LICENSE_PATH" >> "$GITHUB_ENV"
           echo "BC_LICENSE_FILE=/bc/custom-license.bclicense" >> "$GITHUB_ENV"
           echo "ISV license staged for entrypoint import"
+
+      # ─── Phase 3.9: claim the container stack ────────────────────────
+      # Everything from here to the end of the job drives containers whose
+      # names and ports are shared by every job on this docker host. Take the
+      # machine-wide lease first, so a job that arrives while this one is
+      # mid-test queues instead of running `docker compose down` on our BC.
+      #
+      # Uncontended — which is every GitHub-hosted run, since the VM is ours
+      # alone — this costs one file create. The step it protects is the next
+      # one; the release is the last step of the job.
+      #
+      # The wait budget stops short of the job timeout so the failure is OUR
+      # message ("the stack is in use by <job>") rather than GitHub's generic
+      # cancellation, which is the exact confusion issue #24 was reported for.
+      - name: Reserve the BC container stack on this machine
+        run: |
+          set -e
+          WAIT=$(( ${{ inputs.timeout_minutes }} - 10 ))
+          [ "$WAIT" -lt 5 ] && WAIT=5
+          bash bc-linux/scripts/ci-lock.sh acquire "$COMPOSE_PROJECT_NAME" \
+            --wait-minutes "$WAIT" \
+            --max-hold-minutes ${{ inputs.timeout_minutes }}
 
       # ─── Phase 4: kick off BC startup in the background ──────────────
       # docker compose up -d returns immediately. BC then takes ~5 minutes
@@ -926,7 +994,9 @@ jobs:
       - name: Publish AL apps to BC
         env:
           AUTH: "BCRUNNER:Admin123!"
-          DEV: "http://localhost:7049/BC/dev"
+          # Built in the shell below rather than pinned here: BC_DEV_PORT moves
+          # with instance_slot, and a step-level `env:` cannot expand another
+          # env var.
           APP_DIRS: ${{ inputs.app_dirs }}
           TEST_APP_DIRS: ${{ inputs.test_app_dirs }}
           EXTRA_SYMBOLS_ARTIFACT_NAME: ${{ inputs.extra_symbols_artifact_name }}
@@ -934,6 +1004,7 @@ jobs:
         run: |
           set -e
           bash bc-linux/scripts/workflow-summary.sh begin PUBLISH "Publish AL apps"
+          DEV="http://localhost:${BC_DEV_PORT}/BC/dev"
           # Source the canonical publish helper from bc-linux. Previously
           # this step had its own inline publish_app that treated EVERY
           # 422 as success, which silently swallowed missing-dependency
@@ -1016,7 +1087,7 @@ jobs:
           EFFECTIVE_RUNNER="${{ inputs.test_runner }}"
           if [ "$EFFECTIVE_RUNNER" = "auto" ]; then
             if [ -x "$HOME/.dotnet/tools/al" ] \
-               && python3 scripts/run-tests-altool.py --probe; then
+               && python3 scripts/run-tests-altool.py --probe --port "$BC_DEV_PORT"; then
               EFFECTIVE_RUNNER="altool"
               echo "auto: server supports the TestRunnerHub — using the altool runner"
             else
@@ -1062,6 +1133,9 @@ jobs:
                 --junit-output "$junit_file" \
                 --altool-cmd "$HOME/.dotnet/tools/al" \
                 --transport auto \
+                --port "$BC_DEV_PORT" \
+                --base-url "http://localhost:${BC_ODATA_PORT}/BC" \
+                --api-port "$BC_API_PORT" \
                 "${COMPANY_ARGS[@]}" \
                 --timeout 30 2>&1 | tee "$tmplog"
             else
@@ -1069,6 +1143,8 @@ jobs:
                 --app "$app" \
                 --codeunit-range "${{ inputs.codeunit_range }}" \
                 --junit-output "$junit_file" \
+                --base-url "http://localhost:${BC_ODATA_PORT}/BC" \
+                --dev-url "http://localhost:${BC_DEV_PORT}/BC/dev" \
                 "${COMPANY_ARGS[@]}" \
                 --timeout 30 2>&1 | tee "$tmplog"
             fi
@@ -1159,3 +1235,13 @@ jobs:
           echo ""
           echo "=== last 500 lines of bc-1 ==="
           docker compose logs bc 2>&1 | tail -500
+
+      # Last step in the job, and after the log dump above — the containers
+      # have to still be ours while that runs. `if: always()` so a failed test
+      # run doesn't leave the next job queueing for two minutes waiting for the
+      # lease to go stale. Deliberately no `docker compose down`: the next job
+      # does its own, and leaving the stack up is what keeps the warm-volume
+      # path warm on a self-hosted runner.
+      - name: Release the BC container stack
+        if: always()
+        run: bash bc-linux/scripts/ci-lock.sh release "$COMPOSE_PROJECT_NAME"

--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -412,13 +412,6 @@ jobs:
       # `docker compose exec` all have to agree about which project they are
       # talking to, and they run in different steps.
       COMPOSE_PROJECT_NAME: ${{ inputs.instance_slot == 0 && 'bc-linux' || format('bc-linux-{0}', inputs.instance_slot) }}
-      SQL_PORT: ${{ 11433 + inputs.instance_slot * 100 }}
-      BC_DEV_PORT: ${{ 7049 + inputs.instance_slot * 100 }}
-      BC_ODATA_PORT: ${{ 7048 + inputs.instance_slot * 100 }}
-      BC_API_PORT: ${{ 7052 + inputs.instance_slot * 100 }}
-      BC_MGMT_PORT: ${{ 7045 + inputs.instance_slot * 100 }}
-      BC_CLIENT_PORT: ${{ 7085 + inputs.instance_slot * 100 }}
-      BC_WEBCLIENT_PORT: ${{ 8080 + inputs.instance_slot * 100 }}
 
     steps:
       # ─── Phase 1: cheap parallel-friendly checkouts ──────────────────
@@ -572,6 +565,35 @@ jobs:
       # The wait budget stops short of the job timeout so the failure is OUR
       # message ("the stack is in use by <job>") rather than GitHub's generic
       # cancellation, which is the exact confusion issue #24 was reported for.
+      # ─── Resolve this job's port block (issue #24) ───────────────────
+      # Shell, not a `${{ }}` expression, because the GitHub Actions expression
+      # language has NO arithmetic operators — only grouping, index, deref,
+      # comparison and boolean. `${{ 11433 + inputs.instance_slot * 100 }}` is
+      # not a value that evaluates to 11433 at slot 0; it is a syntax error that
+      # makes the whole workflow unloadable, so every caller fails instantly
+      # with a zero-duration run named after the file. COMPOSE_PROJECT_NAME
+      # stays a job-level expression because selecting between two strings
+      # needs no arithmetic.
+      #
+      # Written to $GITHUB_ENV rather than job env so later steps still all
+      # agree: docker compose, wait-for-bc-healthy.sh and run-tests.sh's
+      # `docker compose exec` each run in their own step.
+      - name: Resolve the container stack ports
+        run: |
+          set -e
+          SLOT=${{ inputs.instance_slot }}
+          OFF=$(( SLOT * 100 ))
+          {
+            echo "SQL_PORT=$(( 11433 + OFF ))"
+            echo "BC_DEV_PORT=$(( 7049 + OFF ))"
+            echo "BC_ODATA_PORT=$(( 7048 + OFF ))"
+            echo "BC_API_PORT=$(( 7052 + OFF ))"
+            echo "BC_MGMT_PORT=$(( 7045 + OFF ))"
+            echo "BC_CLIENT_PORT=$(( 7085 + OFF ))"
+            echo "BC_WEBCLIENT_PORT=$(( 8080 + OFF ))"
+          } >> "$GITHUB_ENV"
+          echo "slot $SLOT → project ${COMPOSE_PROJECT_NAME}, dev endpoint $(( 7049 + OFF ))"
+
       - name: Reserve the BC container stack on this machine
         run: |
           set -e

--- a/.github/workflows/bc-test-prebuilt.yml
+++ b/.github/workflows/bc-test-prebuilt.yml
@@ -45,6 +45,33 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      instance_slot:
+        description: >
+          Which BC stack on the machine this job should use. Leave at 0 unless
+          you want two jobs running BC on ONE self-hosted machine at the same
+          time.
+
+          Background: Compose names its project after the working directory's
+          basename — `bc-linux` for every job — and docker-compose.yml binds
+          fixed host ports. So every job on a given docker host addresses the
+          same containers and the same ports, and a second job's
+          `docker compose down` deletes the first job's BC mid-test (issue
+          #24). This workflow therefore takes a machine-wide lease around the
+          container lifecycle: jobs sharing a machine queue rather than
+          destroying each other.
+
+          Raising the slot is how you buy real parallelism instead of queueing.
+          Slot N gets its own compose project (`bc-linux-N`) and its own ports,
+          offset by N*100 — slot 1 puts the dev endpoint on 7149, OData on
+          7148, SQL on 11533, and so on. Two jobs on different slots run
+          concurrently; two on the same slot still queue.
+
+          Budget roughly a full BC service tier plus a SQL Server per slot in
+          RAM before raising it. It has no effect on a GitHub-hosted runner —
+          every job there already has a machine to itself.
+        required: false
+        type: number
+        default: 0
       bc_version:
         description: "BC platform version (e.g. 27.5)"
         required: false
@@ -173,6 +200,25 @@ jobs:
       # what makes a warm cache visible to the container instead of being
       # re-downloaded into it.
       BC_ARTIFACTS_DIR: ${{ inputs.artifact_cache_dir != '' && inputs.artifact_cache_dir || format('{0}/artifact-cache', github.workspace) }}/${{ inputs.bc_version }}
+      # ─── Which container stack on this machine is ours (issue #24) ───
+      # Slot 0 keeps the historical identity exactly: project `bc-linux`, the
+      # default ports from docker-compose.yml, and therefore the same named
+      # volumes a self-hosted runner has already warmed. Raising the slot moves
+      # the whole stack — project name AND every published port — so two jobs
+      # can hold BC at once on one machine.
+      #
+      # Job-level rather than step-level for the same reason BC_ARTIFACTS_DIR
+      # is: `docker compose`, `wait-for-bc-healthy.sh` and `run-tests.sh`'s
+      # `docker compose exec` all have to agree about which project they are
+      # talking to, and they run in different steps.
+      COMPOSE_PROJECT_NAME: ${{ inputs.instance_slot == 0 && 'bc-linux' || format('bc-linux-{0}', inputs.instance_slot) }}
+      SQL_PORT: ${{ 11433 + inputs.instance_slot * 100 }}
+      BC_DEV_PORT: ${{ 7049 + inputs.instance_slot * 100 }}
+      BC_ODATA_PORT: ${{ 7048 + inputs.instance_slot * 100 }}
+      BC_API_PORT: ${{ 7052 + inputs.instance_slot * 100 }}
+      BC_MGMT_PORT: ${{ 7045 + inputs.instance_slot * 100 }}
+      BC_CLIENT_PORT: ${{ 7085 + inputs.instance_slot * 100 }}
+      BC_WEBCLIENT_PORT: ${{ 8080 + inputs.instance_slot * 100 }}
 
     steps:
       - name: Checkout your repo
@@ -274,6 +320,28 @@ jobs:
           echo "BC_LICENSE_FILE=/bc/custom-license.bclicense" >> "$GITHUB_ENV"
           echo "ISV license staged for entrypoint import"
 
+      # ─── Claim the container stack ───────────────────────────────────
+      # Everything from here to the end of the job drives containers whose
+      # names and ports are shared by every job on this docker host. Take the
+      # machine-wide lease first, so a job that arrives while this one is
+      # mid-test queues instead of running `docker compose down` on our BC.
+      #
+      # Uncontended — which is every GitHub-hosted run, since the VM is ours
+      # alone — this costs one file create. The step it protects is the next
+      # one; the release is the last step of the job.
+      #
+      # The wait budget stops short of the job timeout so the failure is OUR
+      # message ("the stack is in use by <job>") rather than GitHub's generic
+      # cancellation, which is the exact confusion issue #24 was reported for.
+      - name: Reserve the BC container stack on this machine
+        run: |
+          set -e
+          WAIT=$(( ${{ inputs.timeout_minutes }} - 10 ))
+          [ "$WAIT" -lt 5 ] && WAIT=5
+          bash bc-linux/scripts/ci-lock.sh acquire "$COMPOSE_PROJECT_NAME" \
+            --wait-minutes "$WAIT" \
+            --max-hold-minutes ${{ inputs.timeout_minutes }}
+
       # No compile in prebuilt mode, so there's nothing CPU-bound to overlap
       # with BC startup — but we still kick off in the background to allow
       # the eventual workflow-summary phase tracking to be cleaner.
@@ -303,12 +371,15 @@ jobs:
       - name: Publish .app files
         env:
           AUTH: "BCRUNNER:Admin123!"
-          DEV: "http://localhost:7049/BC/dev"
+          # Built in the shell below rather than pinned here: BC_DEV_PORT moves
+          # with instance_slot, and a step-level `env:` cannot expand another
+          # env var.
           APP_FILES: ${{ inputs.app_files }}
           TEST_APP_FILES: ${{ inputs.test_app_files }}
         run: |
           set -e
           bash bc-linux/scripts/workflow-summary.sh begin PUBLISH "Publish .app files"
+          DEV="http://localhost:${BC_DEV_PORT}/BC/dev"
           # Source the canonical publish helper. Previously this step had
           # its own inline publish_app that treated EVERY 422 as success
           # and silently swallowed missing-dependency / schema-sync errors,
@@ -367,6 +438,8 @@ jobs:
               --app "../project/$app" \
               --codeunit-range "${{ inputs.codeunit_range }}" \
               --junit-output "$junit_file" \
+              --base-url "http://localhost:${BC_ODATA_PORT}/BC" \
+              --dev-url "http://localhost:${BC_DEV_PORT}/BC/dev" \
               "${COMPANY_ARGS[@]}" \
               --timeout 30 2>&1 | tee "$tmplog"
             # `tee` always exits 0; capture run-tests.sh's real exit code.
@@ -437,3 +510,13 @@ jobs:
         if: failure()
         working-directory: bc-linux
         run: docker compose logs bc | tail -200
+
+      # Last step in the job, and after the log dump above — the containers
+      # have to still be ours while that runs. `if: always()` so a failed test
+      # run doesn't leave the next job queueing for two minutes waiting for the
+      # lease to go stale. Deliberately no `docker compose down`: the next job
+      # does its own, and leaving the stack up is what keeps the warm-volume
+      # path warm on a self-hosted runner.
+      - name: Release the BC container stack
+        if: always()
+        run: bash bc-linux/scripts/ci-lock.sh release "$COMPOSE_PROJECT_NAME"

--- a/.github/workflows/bc-test-prebuilt.yml
+++ b/.github/workflows/bc-test-prebuilt.yml
@@ -212,13 +212,6 @@ jobs:
       # `docker compose exec` all have to agree about which project they are
       # talking to, and they run in different steps.
       COMPOSE_PROJECT_NAME: ${{ inputs.instance_slot == 0 && 'bc-linux' || format('bc-linux-{0}', inputs.instance_slot) }}
-      SQL_PORT: ${{ 11433 + inputs.instance_slot * 100 }}
-      BC_DEV_PORT: ${{ 7049 + inputs.instance_slot * 100 }}
-      BC_ODATA_PORT: ${{ 7048 + inputs.instance_slot * 100 }}
-      BC_API_PORT: ${{ 7052 + inputs.instance_slot * 100 }}
-      BC_MGMT_PORT: ${{ 7045 + inputs.instance_slot * 100 }}
-      BC_CLIENT_PORT: ${{ 7085 + inputs.instance_slot * 100 }}
-      BC_WEBCLIENT_PORT: ${{ 8080 + inputs.instance_slot * 100 }}
 
     steps:
       - name: Checkout your repo
@@ -333,6 +326,35 @@ jobs:
       # The wait budget stops short of the job timeout so the failure is OUR
       # message ("the stack is in use by <job>") rather than GitHub's generic
       # cancellation, which is the exact confusion issue #24 was reported for.
+      # ─── Resolve this job's port block (issue #24) ───────────────────
+      # Shell, not a `${{ }}` expression, because the GitHub Actions expression
+      # language has NO arithmetic operators — only grouping, index, deref,
+      # comparison and boolean. `${{ 11433 + inputs.instance_slot * 100 }}` is
+      # not a value that evaluates to 11433 at slot 0; it is a syntax error that
+      # makes the whole workflow unloadable, so every caller fails instantly
+      # with a zero-duration run named after the file. COMPOSE_PROJECT_NAME
+      # stays a job-level expression because selecting between two strings
+      # needs no arithmetic.
+      #
+      # Written to $GITHUB_ENV rather than job env so later steps still all
+      # agree: docker compose, wait-for-bc-healthy.sh and run-tests.sh's
+      # `docker compose exec` each run in their own step.
+      - name: Resolve the container stack ports
+        run: |
+          set -e
+          SLOT=${{ inputs.instance_slot }}
+          OFF=$(( SLOT * 100 ))
+          {
+            echo "SQL_PORT=$(( 11433 + OFF ))"
+            echo "BC_DEV_PORT=$(( 7049 + OFF ))"
+            echo "BC_ODATA_PORT=$(( 7048 + OFF ))"
+            echo "BC_API_PORT=$(( 7052 + OFF ))"
+            echo "BC_MGMT_PORT=$(( 7045 + OFF ))"
+            echo "BC_CLIENT_PORT=$(( 7085 + OFF ))"
+            echo "BC_WEBCLIENT_PORT=$(( 8080 + OFF ))"
+          } >> "$GITHUB_ENV"
+          echo "slot $SLOT → project ${COMPOSE_PROJECT_NAME}, dev endpoint $(( 7049 + OFF ))"
+
       - name: Reserve the BC container stack on this machine
         run: |
           set -e

--- a/.github/workflows/check-example-drift.yml
+++ b/.github/workflows/check-example-drift.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Check examples against the reusable workflows
         run: python3 scripts/check-example-drift.py
 
+      # ci-lock.sh runs on every pipeline in the repo and in every consumer
+      # that copied an example, and nothing else lints it — the only other
+      # shellcheck pass in CI is snapshot-scoped (test-snapshot.yml). A bug
+      # here breaks the container lifecycle for everybody, and shellcheck is
+      # free on a job that already exists and already triggers on scripts/**.
+      - name: Lint the shared lock script
+        run: shellcheck -S warning scripts/ci-lock.sh
+
       - name: Validate example YAML and shell syntax
         run: |
           set -e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Significantly hardened during the bc-copilot-blueprint bring-up session in
 selective filter, or `resolve-keep-app-ids.py` should read this whole
 section first.
 
-### The four shared scripts
+### The five shared scripts
 
 | Script | What it does | Used from |
 |---|---|---|
@@ -115,6 +115,50 @@ section first.
 | `scripts/stage-symbols.py` | Manifest-driven `.alpackages` staging. Walks an artifact tree, indexes every `.app` by id, then copies into the output dir exactly the symbols needed: System.app + Application umbrella + the consumer's transitive dependency closure. Replaces the older glob-based staging that silently missed apps when Microsoft moved files between BC versions. | `bc-test-from-source.yml`, `bc-copilot-blueprint`'s `copilot-setup-steps.yml` |
 | `scripts/publish-app.sh` | Sourceable shared helper exposing `bc_publish_app <path> [dev_url] [auth]`. Reads the response body and only treats 422 as success when it actually says "already" (catches missing-dependency / schema-sync / version-conflict failures that the previous duplicated inline `publish_app` functions silently swallowed). | `run-tests.sh`, all three workflows, `bc-copilot-blueprint`'s `iterate.sh` |
 | `scripts/wait-for-bc-healthy.sh` | Single canonical "block until docker healthcheck reports `healthy`" loop with progress lines every 60s. Replaces 4 previously-inlined copies across the workflows. | All three workflows, `iterate.sh` (could migrate, currently has its own variant) |
+| `scripts/ci-lock.sh` | Machine-wide lease around the BC/SQL container lifecycle. Heartbeat-refreshed lease file, stolen once nobody has touched it for `BC_CI_LOCK_STALE_SECONDS`. | Both reusable workflows and all four examples |
+
+### Two jobs on one machine share the containers, and that is issue #24
+
+Compose derives its project name from the working directory's basename —
+`bc-linux` for every pipeline everywhere — and `docker-compose.yml` binds
+fixed host ports. So *any* two jobs on one docker host address the same
+`bc-linux-bc-1` / `bc-linux-sql-1` and the same 7045-7089/8080/11433,
+regardless of how their workspaces are laid out. The second job's
+`docker compose down --remove-orphans` deletes the first job's BC mid-test.
+
+Two things made this expensive to find, and both are worth remembering:
+
+- **The symptom names the wrong thing.** Both jobs die with GitHub's
+  `The runner has received a shutdown signal` / `exit code 143`, which reads
+  as an infrastructure problem. Retriggering either PR alone passed with no
+  other change, which reads as flakiness. Neither points at containers.
+- **The existing `flock` looked like it covered this.** `download-artifacts.sh`
+  locks the artifact cache and `CLAUDE.md` said concurrent runners were safe —
+  true, and only about the cache. The containers were never locked.
+
+`ci-lock.sh` closes it: acquire before the `down`/`up`, release as the job's
+last step. Not flock — a CI job's steps are separate processes, so the lock has
+to outlive the step that took it. It is a lease file refreshed by a background
+heartbeat, and a lease nobody has touched for 120s is treated as abandoned.
+That last part is what makes a killed job self-heal instead of wedging the
+machine: the heartbeat is deliberately NOT `setsid`, so it dies with the job's
+process group.
+
+Two invariants if you touch it:
+
+- **Release must be the last step, after the log dump**, and must verify the
+  token before deleting. It runs `if: always()`, including on paths where
+  acquire never ran; a blind `rm` there would hand a running job's stack to
+  somebody else.
+- **Serializing is the default, not the goal.** `instance_slot: N` on either
+  reusable workflow moves the compose project to `bc-linux-N` AND every port by
+  N*100, which is what actually buys parallelism. Moving only the project name
+  would convert a silent teardown into a port bind conflict — the fixed ports
+  are half the collision.
+
+Snapshot mode is the exception: `docker-compose.snapshot.yml` needs
+`network_mode: host`, which makes the port variables inert, so slots cannot
+isolate it. Serialize it (`bench-selfhosted.yml` uses a `concurrency:` group).
 
 ### How extensions get installed for tenant
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,43 @@ BC_CLIENT_PORT=17085
 docker compose -p bc280 --env-file .env.bc280 up -d --wait
 ```
 
+### …and the same thing in CI
+
+The constraint above — one project name and one port set per BC — is what
+makes two CI jobs on one machine dangerous rather than merely slow. Compose
+derives the project name from the working directory's basename, which is
+`bc-linux` in every pipeline, so two jobs on one docker host address the same
+`bc-linux-bc-1` and `bc-linux-sql-1`. The second job's
+`docker compose down --remove-orphans` deletes the first job's BC in the
+middle of its test run, and both die with GitHub's generic "the runner has
+received a shutdown signal" — which points nowhere near the cause
+([issue #24](https://github.com/StefanMaron/MsDyn365Bc.On.Linux/issues/24)).
+
+Every pipeline in this repo therefore takes a machine-wide lease
+(`scripts/ci-lock.sh`) around the container lifecycle, so jobs sharing a
+machine queue instead of destroying each other. On a GitHub-hosted runner the
+lease is uncontended and costs a single file create.
+
+Queueing is the safe default, not the fast one. To actually run two BCs at
+once on one self-hosted machine, give each caller its own slot:
+
+```yaml
+jobs:
+  bc-tests:
+    uses: StefanMaron/MsDyn365Bc.On.Linux/.github/workflows/bc-test-from-source.yml@master
+    with:
+      instance_slot: 1     # project bc-linux-1; every port +100
+```
+
+Slot N gets the compose project `bc-linux-N` and every published port offset
+by N\*100 (slot 1: dev 7149, OData 7148, API 7152, SQL 11533, …).
+Jobs on different slots run concurrently; jobs on the same slot still queue.
+Budget a full BC service tier plus a SQL Server in RAM per slot.
+
+`ci-lock.sh` is usable on its own, too — `acquire`/`release`/`status`, with
+`BC_CI_LOCK_DIR` pointing at a path shared by everything that shares the
+docker daemon.
+
 ---
 
 ## How it works

--- a/examples/azure-pipelines/bc-test-from-source.yml
+++ b/examples/azure-pipelines/bc-test-from-source.yml
@@ -226,6 +226,31 @@ steps:
       BC_LICENSE_B64: $(BC_LICENSE_B64)
     displayName: 'Stage ISV license (if BC_LICENSE_B64 is set)'
 
+  # Compose names its project after the working directory's basename —
+  # `bc-linux` here and in every other pipeline — and docker-compose.yml binds
+  # fixed host ports. Two jobs on one docker host therefore drive the SAME
+  # containers, and the second one's `docker compose down` in the next step
+  # deletes the first one's BC mid-test (issue #24). ci-lock.sh serializes them
+  # on a machine-wide lease.
+  #
+  # On a Microsoft-hosted agent this is a no-op — the VM belongs to this job.
+  # It earns its place the moment you move to a self-hosted agent, which is
+  # also when the artifact cache and the warm service-tier volume start paying
+  # off.
+  #
+  # The token has to reach the release step at the bottom of the job, and an
+  # `export` does not survive a step boundary here — hence the setvariable.
+  - bash: |
+      set -e
+      cd "$(Agent.BuildDirectory)/bc-linux"
+      bash scripts/ci-lock.sh acquire bc-linux \
+        --wait-minutes 35 --max-hold-minutes 45 | tee /tmp/ci-lock-acquire.log
+      rc=${PIPESTATUS[0]}
+      [ "$rc" -eq 0 ] || exit "$rc"
+      TOKEN=$(sed -n 's/^BC_CI_LOCK_TOKEN=//p' /tmp/ci-lock-acquire.log)
+      echo "##vso[task.setvariable variable=BC_CI_LOCK_TOKEN]$TOKEN"
+    displayName: 'Reserve the BC container stack on this machine'
+
   - bash: |
       set -e
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" begin BC_BOOT "BC startup (background → wait for healthy)"
@@ -241,7 +266,7 @@ steps:
       # is provided as a secret variable). Empty/unset = default Cronus.
       export BC_LICENSE_HOST_PATH="${BC_LICENSE_HOST_PATH:-}"
       export BC_LICENSE_FILE="${BC_LICENSE_FILE:-}"
-      # Clear any leftover compose state before starting. On a GitHub-hosted
+      # Clear any leftover compose state before starting. On a Microsoft-hosted
       # runner this is a no-op (fresh VM, nothing to remove). On a self-hosted
       # one the previous job's bc/sql containers may still be running, and
       # `docker compose up -d` adopts a running container instead of recreating
@@ -618,3 +643,18 @@ steps:
       docker compose logs bc | tail -200
     displayName: 'BC logs (on failure)'
     condition: failed()
+
+  # Last step, and after the log dump — the containers have to still be ours
+  # while that runs. No `docker compose down`: the next job does its own, and
+  # leaving the stack up is what keeps a self-hosted agent's warm-volume path
+  # warm.
+  #
+  # If the acquire step never ran, Azure leaves the macro unexpanded and the
+  # token will not match the lease — release then refuses rather than handing
+  # a running job's stack to somebody else, and the lease is reclaimed on its
+  # own once the heartbeat stops.
+  - bash: |
+      export BC_CI_LOCK_TOKEN="$(BC_CI_LOCK_TOKEN)"
+      bash "$(Agent.BuildDirectory)/bc-linux/scripts/ci-lock.sh" release bc-linux
+    displayName: 'Release the BC container stack'
+    condition: always()

--- a/examples/azure-pipelines/bc-test-prebuilt.yml
+++ b/examples/azure-pipelines/bc-test-prebuilt.yml
@@ -185,6 +185,31 @@ steps:
       BC_LICENSE_B64: $(BC_LICENSE_B64)
     displayName: 'Stage ISV license (if BC_LICENSE_B64 is set)'
 
+  # Compose names its project after the working directory's basename —
+  # `bc-linux` here and in every other pipeline — and docker-compose.yml binds
+  # fixed host ports. Two jobs on one docker host therefore drive the SAME
+  # containers, and the second one's `docker compose down` in the next step
+  # deletes the first one's BC mid-test (issue #24). ci-lock.sh serializes them
+  # on a machine-wide lease.
+  #
+  # On a Microsoft-hosted agent this is a no-op — the VM belongs to this job.
+  # It earns its place the moment you move to a self-hosted agent, which is
+  # also when the artifact cache and the warm service-tier volume start paying
+  # off.
+  #
+  # The token has to reach the release step at the bottom of the job, and an
+  # `export` does not survive a step boundary here — hence the setvariable.
+  - bash: |
+      set -e
+      cd "$(Agent.BuildDirectory)/bc-linux"
+      bash scripts/ci-lock.sh acquire bc-linux \
+        --wait-minutes 35 --max-hold-minutes 45 | tee /tmp/ci-lock-acquire.log
+      rc=${PIPESTATUS[0]}
+      [ "$rc" -eq 0 ] || exit "$rc"
+      TOKEN=$(sed -n 's/^BC_CI_LOCK_TOKEN=//p' /tmp/ci-lock-acquire.log)
+      echo "##vso[task.setvariable variable=BC_CI_LOCK_TOKEN]$TOKEN"
+    displayName: 'Reserve the BC container stack on this machine'
+
   - bash: |
       set -e
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" begin BC_BOOT "BC startup (background → wait for healthy)"
@@ -200,8 +225,8 @@ steps:
       # is provided as a secret variable). Empty/unset = default Cronus.
       export BC_LICENSE_HOST_PATH="${BC_LICENSE_HOST_PATH:-}"
       export BC_LICENSE_FILE="${BC_LICENSE_FILE:-}"
-      # Clear any leftover compose state before starting. On a GitHub-hosted
-      # runner this is a no-op (fresh VM, nothing to remove). On a self-hosted
+      # Clear any leftover compose state before starting. On a Microsoft-hosted
+      # agent this is a no-op (fresh VM, nothing to remove). On a self-hosted
       # one the previous job's bc/sql containers may still be running, and
       # `docker compose up -d` adopts a running container instead of recreating
       # it — the healthcheck then goes green in seconds against the PREVIOUS
@@ -301,3 +326,18 @@ steps:
       docker compose logs bc | tail -200
     displayName: 'BC logs (on failure)'
     condition: failed()
+
+  # Last step, and after the log dump — the containers have to still be ours
+  # while that runs. No `docker compose down`: the next job does its own, and
+  # leaving the stack up is what keeps a self-hosted agent's warm-volume path
+  # warm.
+  #
+  # If the acquire step never ran, Azure leaves the macro unexpanded and the
+  # token will not match the lease — release then refuses rather than handing
+  # a running job's stack to somebody else, and the lease is reclaimed on its
+  # own once the heartbeat stops.
+  - bash: |
+      export BC_CI_LOCK_TOKEN="$(BC_CI_LOCK_TOKEN)"
+      bash "$(Agent.BuildDirectory)/bc-linux/scripts/ci-lock.sh" release bc-linux
+    displayName: 'Release the BC container stack'
+    condition: always()

--- a/examples/github-workflows/bc-test-from-source.yml
+++ b/examples/github-workflows/bc-test-from-source.yml
@@ -244,6 +244,24 @@ jobs:
           echo "BC_LICENSE_HOST_PATH=$LICENSE_PATH" >> "$GITHUB_ENV"
           echo "BC_LICENSE_FILE=/bc/custom-license.bclicense" >> "$GITHUB_ENV"
 
+      # ─── Phase 3.9: claim the container stack ────────────────────────
+      # Compose names its project after the working directory's basename —
+      # `bc-linux` here and in every other pipeline — and docker-compose.yml
+      # binds fixed host ports. Two jobs on one docker host therefore drive the
+      # SAME containers, and the second one's `docker compose down` below
+      # deletes the first one's BC mid-test (issue #24). ci-lock.sh serializes
+      # them on a machine-wide lease.
+      #
+      # On ubuntu-latest this is a no-op — the VM belongs to this job. It
+      # earns its place the moment you point `runs-on` at a self-hosted
+      # runner, which is also when the artifact cache and the warm service-tier
+      # volume start paying off. Use the reusable workflow
+      # (bc-test-from-source.yml) if you want more than one BC per machine; it
+      # exposes an `instance_slot` input that moves the project name and every
+      # port so jobs run concurrently instead of queueing.
+      - name: Reserve the BC container stack on this machine
+        run: bash bc-linux/scripts/ci-lock.sh acquire bc-linux --wait-minutes 35 --max-hold-minutes 45
+
       # ─── Phase 4: kick off BC startup in the background ──────────────
       - name: Start BC on Linux (background)
         working-directory: bc-linux
@@ -623,3 +641,11 @@ jobs:
         if: failure()
         working-directory: bc-linux
         run: docker compose logs bc | tail -200
+
+      # Last step, and after the log dump — the containers have to still be
+      # ours while that runs. No `docker compose down`: the next job does its
+      # own, and leaving the stack up is what keeps a self-hosted runner's
+      # warm-volume path warm.
+      - name: Release the BC container stack
+        if: always()
+        run: bash bc-linux/scripts/ci-lock.sh release bc-linux

--- a/examples/github-workflows/bc-test-prebuilt.yml
+++ b/examples/github-workflows/bc-test-prebuilt.yml
@@ -195,6 +195,22 @@ jobs:
           echo "BC_LICENSE_HOST_PATH=$LICENSE_PATH" >> "$GITHUB_ENV"
           echo "BC_LICENSE_FILE=/bc/custom-license.bclicense" >> "$GITHUB_ENV"
 
+      # Compose names its project after the working directory's basename —
+      # `bc-linux` here and in every other pipeline — and docker-compose.yml
+      # binds fixed host ports. Two jobs on one docker host therefore drive the
+      # SAME containers, and the second one's `docker compose down` below
+      # deletes the first one's BC mid-test (issue #24). ci-lock.sh serializes
+      # them on a machine-wide lease.
+      #
+      # On ubuntu-latest this is a no-op — the VM belongs to this job. It earns
+      # its place the moment you point `runs-on` at a self-hosted runner. Use
+      # the reusable workflow (bc-test-prebuilt.yml) if you want more than one
+      # BC per machine; it exposes an `instance_slot` input that moves the
+      # project name and every port so jobs run concurrently instead of
+      # queueing.
+      - name: Reserve the BC container stack on this machine
+        run: bash bc-linux/scripts/ci-lock.sh acquire bc-linux --wait-minutes 35 --max-hold-minutes 45
+
       - name: Start BC on Linux (background)
         working-directory: bc-linux
         run: |
@@ -294,3 +310,11 @@ jobs:
         if: failure()
         working-directory: bc-linux
         run: docker compose logs bc | tail -200
+
+      # Last step, and after the log dump — the containers have to still be
+      # ours while that runs. No `docker compose down`: the next job does its
+      # own, and leaving the stack up is what keeps a self-hosted runner's
+      # warm-volume path warm.
+      - name: Release the BC container stack
+        if: always()
+        run: bash bc-linux/scripts/ci-lock.sh release bc-linux

--- a/examples/github-workflows/bc-test-using-reusable.yml
+++ b/examples/github-workflows/bc-test-using-reusable.yml
@@ -53,6 +53,20 @@ jobs:
       # runs_on:           "self-hosted"
       # artifact_cache_dir: "/var/cache/bc-artifacts"
 
+      # ─── Optional: more than one BC per self-hosted machine ─────────
+      # Every job that runs BC — yours and everyone else's on the same
+      # docker host — drives the same compose project (`bc-linux`) and the
+      # same host ports, so one job's `docker compose down` deletes
+      # another's BC mid-test. The reusable workflow takes a machine-wide
+      # lease to stop that, which means jobs sharing a machine QUEUE.
+      #
+      # Nothing to do here if that's fine, and nothing to do at all on a
+      # GitHub-hosted runner. To run two BCs side by side on one big
+      # self-hosted machine, give each caller its own slot — slot N moves
+      # the compose project to `bc-linux-N` and every port by N*100:
+      #
+      # instance_slot: 1
+
       # ─── Optional: analyzers + rulesets ─────────────────────────────
       # All off by default. Uncomment to enable. The reusable workflow
       # fails the job if any analyzer DLL fails to load (AD0001,

--- a/scripts/ci-lock.sh
+++ b/scripts/ci-lock.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# ci-lock.sh — machine-wide mutual exclusion for the BC/SQL container stack.
+#
+# WHY THIS EXISTS
+# ---------------
+# Every pipeline in this repo drives the stack with
+#
+#     docker compose down --remove-orphans
+#     docker compose up -d
+#
+# and Compose derives the project name from the working directory's basename,
+# which is `bc-linux` for every job everywhere. So two jobs that land on the
+# same docker host address the SAME containers — `bc-linux-bc-1`,
+# `bc-linux-sql-1` — no matter how their workspaces are laid out. The second
+# job's `down` deletes the first job's BC mid-test.
+#
+# That is issue #24. What made it expensive to diagnose is that the symptom
+# points nowhere near the cause: both jobs die with GitHub's generic
+#
+#     The runner has received a shutdown signal.
+#     Process completed with exit code 143.
+#
+# which reads as "somebody stopped the runner service", not "another job
+# deleted my container". Two PR builds on one self-hosted runner reproduced it
+# exactly; retriggering either one alone passed with no other change.
+#
+# The fixed host ports in docker-compose.yml (7045-7089, 8080, 11433) mean the
+# same thing from the other direction: even with distinct project names, two
+# concurrent stacks on one machine cannot both bind them. Sharing the machine
+# is inherently serial unless the caller has explicitly moved the ports, which
+# is what the reusable workflows' `instance_slot` input does.
+#
+# So this is a lease, not an isolation scheme: hold it around the whole
+# down/up/publish/test region and concurrent jobs queue instead of destroying
+# each other. It is the same instinct as `download-artifacts.sh`'s flock on the
+# artifact cache, extended to the resource the flock never covered.
+#
+# USAGE
+#   scripts/ci-lock.sh acquire <name> [--wait-minutes N] [--max-hold-minutes N]
+#   scripts/ci-lock.sh release <name>
+#   scripts/ci-lock.sh status  <name>
+#
+# `acquire` blocks until the lease is free, then prints — and, under GitHub
+# Actions, appends to $GITHUB_ENV — the token that `release` needs:
+#
+#   BC_CI_LOCK_TOKEN=<random>
+#
+# so the release step in a later part of the same job identifies itself. A
+# release without a matching token is refused rather than stealing somebody
+# else's lease, which matters because the workflows run it with `if: always()`.
+#
+# WHY NOT flock(1)
+# ----------------
+# flock holds only as long as the process holding the fd. A CI job's steps are
+# separate processes, so the lock has to outlive the step that took it. This
+# keeps a lease FILE, refreshed by a background heartbeat, and treats a lease
+# nobody has touched for BC_CI_LOCK_STALE_SECONDS as abandoned. That is also
+# what makes the failure mode self-healing: a job killed the way the two in
+# issue #24 were killed leaves its lease behind, its heartbeat dies with the
+# job's process group, and the next job takes over ~2 minutes later instead of
+# being blocked until somebody logs in.
+#
+# ENVIRONMENT
+#   BC_CI_LOCK_DIR              where leases live. Default /var/tmp/bc-linux-ci-locks.
+#                               MUST be shared by everything sharing the docker
+#                               daemon — if your runners are themselves
+#                               containers talking to a mounted docker socket,
+#                               point this at a path mounted into all of them.
+#   BC_CI_LOCK_TOKEN            set by acquire, consumed by release.
+#   BC_CI_LOCK_STALE_SECONDS    abandonment threshold. Default 120.
+#   BC_CI_LOCK_HEARTBEAT_SECONDS  refresh interval. Default 30.
+#   BC_CI_LOCK_POLL_SECONDS     wait-loop interval. Default 5.
+#   BC_CI_LOCK_DISABLE=1        make acquire/release no-ops. Escape hatch for a
+#                               machine where the lease dir cannot be shared and
+#                               the operator knows jobs never overlap.
+#
+# EXIT CODES
+#   0  acquired / released / (status) free
+#   1  usage error, or the lease could not be created at all
+#   2  acquire timed out — another job still holds the stack
+#   3  (status) held by somebody else
+
+set -uo pipefail
+
+LOCK_DIR="${BC_CI_LOCK_DIR:-/var/tmp/bc-linux-ci-locks}"
+STALE_SECONDS="${BC_CI_LOCK_STALE_SECONDS:-120}"
+HEARTBEAT_SECONDS="${BC_CI_LOCK_HEARTBEAT_SECONDS:-30}"
+POLL_SECONDS="${BC_CI_LOCK_POLL_SECONDS:-5}"
+
+usage() {
+    sed -n '/^# USAGE/,/^#$/p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+# GNU coreutils first, BSD/macOS second. Nothing else is expected; a machine
+# with neither gets an empty string, which the callers read as "no mtime", i.e.
+# infinitely old — the conservative direction is to NOT steal, so both callers
+# treat an unreadable mtime as fresh.
+lease_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo ""
+}
+
+# The lease is a few `key=value` lines. Read one without sourcing the file —
+# it is written by another job and must never be executed.
+lease_field() {
+    sed -n "s/^$2=//p" "$1" 2>/dev/null | head -1
+}
+
+describe_holder() {
+    local lease="$1" age
+    age=$(lease_age "$lease")
+    printf '    held by : %s\n' "$(lease_field "$lease" who)"
+    printf '    run     : %s\n' "$(lease_field "$lease" run)"
+    printf '    since   : %s (%ss ago)\n' "$(lease_field "$lease" started)" "${age:-?}"
+}
+
+lease_age() {
+    local mtime now
+    mtime=$(lease_mtime "$1")
+    [ -n "$mtime" ] || return 0
+    now=$(date +%s)
+    echo $(( now - mtime ))
+}
+
+# Atomic create-or-fail. `set -o noclobber` turns `>` into O_CREAT|O_EXCL, so
+# exactly one of N racing writers wins. (On NFS that guarantee is weaker; see
+# BC_CI_LOCK_DIR above — a lease dir on NFS is not a supported configuration.)
+try_create() {
+    local lease="$1" payload="$2"
+    ( set -o noclobber; printf '%s\n' "$payload" > "$lease" ) 2>/dev/null
+}
+
+start_heartbeat() {
+    local lease="$1" token="$2" deadline="$3"
+    # NOT setsid: this must die with the job's process group. A heartbeat that
+    # outlives a killed job would keep refreshing a lease nobody owns, which is
+    # precisely the wedge this script exists to avoid.
+    #
+    # The redirect is load-bearing under GitHub Actions: the runner waits for a
+    # step's stdout/stderr pipes to close, so a background process still
+    # holding them hangs the step forever.
+    (
+        while :; do
+            sleep "$HEARTBEAT_SECONDS"
+            [ -f "$lease" ] || break
+            [ "$(lease_field "$lease" token)" = "$token" ] || break
+            [ "$(date +%s)" -lt "$deadline" ] || break
+            touch "$lease" 2>/dev/null || break
+        done
+    ) >/dev/null 2>&1 &
+    echo $!
+}
+
+cmd_acquire() {
+    local name="$1"; shift
+    local wait_minutes=30 max_hold_minutes=120
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --wait-minutes)     wait_minutes="$2"; shift 2 ;;
+            --max-hold-minutes) max_hold_minutes="$2"; shift 2 ;;
+            *) echo "ci-lock: unknown option '$1'" >&2; usage ;;
+        esac
+    done
+
+    local lease="$LOCK_DIR/$name.lease"
+    local token who run started
+    token="$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+    who="${RUNNER_NAME:-$(hostname)}${GITHUB_JOB:+ / job $GITHUB_JOB}"
+    run="${GITHUB_SERVER_URL:-}${GITHUB_REPOSITORY:+/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID}"
+    started="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+    local now start deadline hold_deadline payload
+    start=$(date +%s)
+    deadline=$(( start + wait_minutes * 60 ))
+    hold_deadline=$(( start + max_hold_minutes * 60 ))
+    payload="token=$token
+who=$who
+run=$run
+started=$started
+pid=$$"
+
+    local announced=0 last_progress=$start
+    while :; do
+        if try_create "$lease" "$payload"; then
+            # Verify after the fact. A waiter that judged this lease stale can
+            # have deleted it in the window between our create and now, then
+            # created its own — in which case we do NOT hold the stack and have
+            # to go back to waiting. Cheap insurance against a double steal.
+            sleep 1
+            if [ "$(lease_field "$lease" token)" != "$token" ]; then
+                continue
+            fi
+            local hb
+            hb=$(start_heartbeat "$lease" "$token" "$hold_deadline")
+            printf 'hb=%s\n' "$hb" >> "$lease"
+            local waited=$(( $(date +%s) - start ))
+            if [ "$waited" -ge "$POLL_SECONDS" ]; then
+                echo "ci-lock: acquired '$name' after ${waited}s"
+            else
+                echo "ci-lock: acquired '$name'"
+            fi
+            echo "BC_CI_LOCK_TOKEN=$token"
+            [ -n "${GITHUB_ENV:-}" ] && echo "BC_CI_LOCK_TOKEN=$token" >> "$GITHUB_ENV"
+            return 0
+        fi
+
+        # Somebody holds it. Decide whether they are still alive.
+        local age
+        age=$(lease_age "$lease")
+        if [ -z "$age" ] && [ ! -f "$lease" ]; then
+            # It vanished between the create attempt and the stat — retry
+            # immediately rather than sleeping out a whole poll interval.
+            continue
+        fi
+
+        if [ -n "$age" ] && [ "$age" -gt "$STALE_SECONDS" ]; then
+            # Re-read after a pause and only steal if nothing moved. A holder
+            # whose heartbeat is merely late gets a second chance; one whose
+            # job was killed does not touch the file again, ever.
+            local token_before
+            token_before=$(lease_field "$lease" token)
+            sleep "$POLL_SECONDS"
+            if [ "$(lease_field "$lease" token)" = "$token_before" ]; then
+                age=$(lease_age "$lease")
+                if [ -n "$age" ] && [ "$age" -gt "$STALE_SECONDS" ]; then
+                    echo "ci-lock: lease '$name' has not been refreshed for ${age}s — treating it as abandoned"
+                    describe_holder "$lease"
+                    rm -f "$lease"
+                fi
+            fi
+            continue
+        fi
+
+        now=$(date +%s)
+        if [ "$now" -ge "$deadline" ]; then
+            echo "ci-lock: ERROR — timed out after ${wait_minutes} min waiting for '$name'." >&2
+            echo "         The BC/SQL container stack on this machine is in use by another job:" >&2
+            describe_holder "$lease" >&2
+            echo "" >&2
+            echo "         Jobs sharing a docker host share the compose project name and the" >&2
+            echo "         host ports, so they cannot run at once (issue #24). To run them in" >&2
+            echo "         parallel, give each job its own stack with the reusable workflow's" >&2
+            echo "         'instance_slot' input, and make sure the machine has the RAM for" >&2
+            echo "         two BC service tiers." >&2
+            return 2
+        fi
+
+        if [ "$announced" -eq 0 ]; then
+            echo "ci-lock: '$name' is held — waiting up to ${wait_minutes} min."
+            describe_holder "$lease"
+            announced=1
+        elif [ $(( now - last_progress )) -ge 60 ]; then
+            echo "ci-lock:   still waiting for '$name' ($(( (now - start) / 60 )) min elapsed)"
+            last_progress=$now
+        fi
+        sleep "$POLL_SECONDS"
+    done
+}
+
+cmd_release() {
+    local name="$1"
+    local lease="$LOCK_DIR/$name.lease"
+    local token="${BC_CI_LOCK_TOKEN:-}"
+
+    if [ ! -f "$lease" ]; then
+        echo "ci-lock: '$name' was already free"
+        return 0
+    fi
+    if [ -z "$token" ]; then
+        # Reached when acquire never ran (an early step failed) or when
+        # $GITHUB_ENV did not propagate. Releasing blind here would hand the
+        # stack to a second job while this one is still using it, so don't.
+        echo "ci-lock: BC_CI_LOCK_TOKEN is unset — leaving '$name' alone."
+        echo "         It will be reclaimed automatically after ${STALE_SECONDS}s without a heartbeat."
+        return 0
+    fi
+    if [ "$(lease_field "$lease" token)" != "$token" ]; then
+        echo "ci-lock: '$name' is held by a different job now — not releasing."
+        describe_holder "$lease"
+        return 0
+    fi
+
+    local hb
+    hb=$(lease_field "$lease" hb)
+    rm -f "$lease"
+    # After the lease is gone the heartbeat exits on its own within one
+    # interval; killing it just makes that immediate.
+    [ -n "$hb" ] && kill "$hb" 2>/dev/null
+    echo "ci-lock: released '$name'"
+    return 0
+}
+
+cmd_status() {
+    local name="$1"
+    local lease="$LOCK_DIR/$name.lease"
+    if [ ! -f "$lease" ]; then
+        echo "ci-lock: '$name' is free"
+        return 0
+    fi
+    echo "ci-lock: '$name' is held"
+    describe_holder "$lease"
+    return 3
+}
+
+main() {
+    [ $# -ge 2 ] || usage
+    local cmd="$1" name="$2"; shift 2
+
+    # Keep the lease filename to something a filesystem is guaranteed to
+    # accept: the caller builds the name from a compose project name, which
+    # may carry anything a directory basename can.
+    name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')"
+
+    if [ "${BC_CI_LOCK_DISABLE:-}" = "1" ]; then
+        echo "ci-lock: disabled via BC_CI_LOCK_DISABLE — '$cmd $name' is a no-op"
+        return 0
+    fi
+
+    if ! mkdir -p "$LOCK_DIR" 2>/dev/null; then
+        echo "ci-lock: ERROR — cannot create lease directory $LOCK_DIR" >&2
+        echo "         Set BC_CI_LOCK_DIR to a writable path shared by every job on this machine." >&2
+        return 1
+    fi
+    # Shared by design: two runner services usually run as different users, and
+    # both have to be able to take the lease. Best-effort — a pre-existing
+    # directory owned by somebody else will not change mode, and does not need
+    # to as long as it is already group/world writable.
+    chmod 1777 "$LOCK_DIR" 2>/dev/null || true
+
+    case "$cmd" in
+        acquire) cmd_acquire "$name" "$@" ;;
+        release) cmd_release "$name" ;;
+        status)  cmd_status  "$name" ;;
+        *) echo "ci-lock: unknown command '$cmd'" >&2; usage ;;
+    esac
+}
+
+main "$@"

--- a/scripts/run-tests-altool.py
+++ b/scripts/run-tests-altool.py
@@ -957,6 +957,10 @@ def main() -> int:
     ap.add_argument("--server-instance", default="BC", help="NST instance name (default BC)")
     ap.add_argument("--port", type=int, default=7049, help="dev endpoint port (default 7049)")
     ap.add_argument("--base-url", default="http://localhost:7048/BC", help="OData base URL for company auto-detect")
+    ap.add_argument("--api-port", type=int, default=7052,
+                    help="API port used for the company auto-detect fallback (default 7052). "
+                         "Only differs from the default when the caller has moved BC's published "
+                         "ports — see the reusable workflows' instance_slot input.")
     ap.add_argument("--timeout", type=int, default=30, help="overall timeout, minutes (default 30)")
     ap.add_argument("--codeunit-timeout", type=int, default=10, help="per-codeunit timeout, minutes (default 10)")
     ap.add_argument("--altool-cmd", default="al", help="AL dotnet tool command or path (default 'al')")
@@ -1020,7 +1024,7 @@ def main() -> int:
         origin = re.sub(r"(https?://[^:/]+).*", r"\1", args.base_url)
         detect_start = time.monotonic()
         company = detect_company(
-            [args.base_url, f"{origin}:7052/BC"], user, password
+            [args.base_url, f"{origin}:{args.api_port}/BC"], user, password
         )
         detect_elapsed = time.monotonic() - detect_start
         if company:


### PR DESCRIPTION
Closes #24. **Replaces #25** — see the last section.

## The bug

Compose derives its project name from the working directory's basename — `bc-linux` in every pipeline — and `docker-compose.yml` binds fixed host ports. So any two jobs on one docker host address the same `bc-linux-bc-1` / `bc-linux-sql-1` and the same 7045-7089 / 8080 / 11433, however their workspaces are laid out. The second job's `docker compose down --remove-orphans` deletes the first job's BC in the middle of its test run.

Both jobs then die with GitHub's generic *"the runner has received a shutdown signal"* / exit 143, which reads as a stopped runner service — and retriggering either one alone passes. That misdirection cost a long detour through runner infrastructure and version pins before the mechanism showed up in the logs.

`download-artifacts.sh` already `flock`s the artifact cache, and the docs said concurrent runners were safe. True — and only about the cache. **The containers were never locked.**

## The fix

`scripts/ci-lock.sh` takes a machine-wide lease around the container lifecycle: acquire before the down/up, release as the job's last step.

Not `flock`, because a CI job's steps are separate processes and the lock has to outlive the step that took it. It's a lease file refreshed by a background heartbeat; a lease nobody has touched for 120s is treated as abandoned. The heartbeat is deliberately **not** `setsid`'d, so a job killed the way those two were killed loses its heartbeat with its process group and the next job takes over on its own instead of wedging the machine. Release verifies the token first — it runs `if: always()`, including on paths where acquire never ran, and a blind `rm` there would hand a running job's stack to somebody else.

## Queueing is correct, not fast

`instance_slot: N` on either reusable workflow buys real parallelism instead: it moves the compose project to `bc-linux-N` **and** every published port by N×100. Moving only the project name would have converted a silent teardown into a port bind conflict — the fixed ports are half the collision.

**Slot 0 is byte-for-byte today's identity**, so a self-hosted runner's warm named volumes stay warm.

Ports reaching that far means the callers stop assuming 7048/7049: the publish step builds its dev URL from `BC_DEV_PORT`, `run-tests.sh` is called with `--base-url`/`--dev-url`, and `run-tests-altool.py` gains `--api-port` for the company auto-detect fallback that had 7052 hardcoded.

All four starter pipelines take the lease too — they inline the same down/up and have the same bug, and consumers who copied one rather than calling the reusable workflow are exactly who issue #19 taught us to fix at the same time. Azure Pipelines needs the token via `setvariable`, since an `export` does not survive a step boundary there.

**Snapshot mode is the exception and is left alone:** it needs `network_mode: host`, which makes the port variables inert, so slots cannot isolate it. `bench-selfhosted.yml` already serializes with a concurrency group.

## Why this PR instead of #25

The commit was pushed to `claude/hosted-runner-performance-42ljw4` after that branch had already been split into #22 and #23, so it never went through either. #25 proposes that whole branch — 82 commits, `mergeable_state: dirty` — whose content is already in master but from history that predates five fixes made during the split. Merging it would revert the artifact-stamp fix (`eeabfe0`, the insider-leg regression) and the shellcheck fix (`cb66d89`), drop the examples' `ARTIFACT_CACHE_DIR` knob, and resurrect `pick-runner` and the GC sweep harness.

This is the only commit on that branch master doesn't have. Cherry-picked onto master; two conflicts, both in regions the split rewrote, resolved by keeping both sides. The resulting diff is identical in shape to the original commit — 12 files, +752/−8.

## Validation

`check-example-drift.py` passes, every example's YAML and all 58 shell blocks parse, and `shellcheck -S warning` is clean on `ci-lock.sh` — which `check-example-drift.yml` now lints, since it already triggers on `scripts/**` and the only other shellcheck pass in CI is snapshot-scoped.

Not exercised here: two jobs actually racing on one machine. That needs a self-hosted runner and is the thing to try before trusting `instance_slot` above 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wowqmese2utM9WUG5H8zP1)_