### PR TITLE
Make the BC login and web client path base configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,27 @@ After `docker compose up`, these are available:
 | Client (WS)  | `ws://localhost:7085/BC`                  | WebSocket client services (TestPage) |
 | Web client   | `http://localhost:8080`                   | Browser UI (opt-in, `BC_WEBCLIENT=1`) |
 
-**Authentication:** `BCRUNNER` / `Admin123!` (NavUserPassword).
+**Authentication:** `BCRUNNER` / `Admin123!` (NavUserPassword) by default.
 Note the username is *not* `admin` — `BCRUNNER` is used so test code that
 needs to delete a user named "ADMIN" doesn't nuke the runner's own session.
+
+Override with `BC_SERVER_USERNAME` / `BC_SERVER_PASSWORD`:
+
+```bash
+BC_SERVER_USERNAME=MYUSER BC_SERVER_PASSWORD='MyP@ss1!' docker compose up -d --wait
+curl -sf -u MYUSER:MyP@ss1! http://localhost:7048/BC/ODataV4/Company
+```
+
+The scripts in `scripts/` (`run-tests.sh`, `run-tests-altool.py`,
+`run-tests-hybrid.py`, `publish-app.sh`, etc.) pick the same two env vars up
+automatically, so no `--auth` flag is needed once the container was booted
+with them. Password verification is not actually enforced on Linux —
+`NavUser.TryAuthenticate`'s hash check doesn't port from Windows, so
+StartupHook Patch #16b bypasses it and any password authenticates as an
+existing, enabled user. `BC_SERVER_PASSWORD` still works end-to-end (that
+exact value is what you type/pass), it just isn't a real access control —
+this is a local dev/CI sandbox account, not something to expose to an
+untrusted network.
 
 ### Web client (browser UI)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,17 @@ services:
       BC_COUNTRY: ${BC_COUNTRY:-w1}
       BC_TYPE: ${BC_TYPE:-sandbox}
       SA_PASSWORD: ${SA_PASSWORD:-Passw0rd123!}
+      # The NavUserPassword login the entrypoint creates for OData/SOAP/dev-endpoint/
+      # web-client sign-in (SUPER access). Defaults preserve the long-documented
+      # BCRUNNER/Admin123! pair; override both to change the account name, e.g. when
+      # a consumer's own tooling expects a specific username. Note the *password*
+      # here is cosmetic, not enforced: NavUser.TryAuthenticate's hash check doesn't
+      # verify on Linux (StartupHook Patch #16b bypasses it and always succeeds), so
+      # ANY password authenticates as this user — see scripts/entrypoint.sh. This is
+      # a local dev/CI sandbox account, not a security boundary; don't expose these
+      # ports to an untrusted network.
+      BC_SERVER_USERNAME: ${BC_SERVER_USERNAME:-BCRUNNER}
+      BC_SERVER_PASSWORD: ${BC_SERVER_PASSWORD:-Admin123!}
       BC_CLEAR_ALL_APPS: ${BC_CLEAR_ALL_APPS:-false}
       BC_SKIP_APP_PUBLISH: ${BC_SKIP_APP_PUBLISH:-false}
       BC_KEEP_APP_IDS: ${BC_KEEP_APP_IDS:-}
@@ -129,6 +140,11 @@ services:
       # Opt-in: self-host Microsoft's real BC web client on Kestrel (port 8080).
       # EXPERIMENTAL PoC — see docs/WEBCLIENT-POC.md.
       BC_WEBCLIENT: ${BC_WEBCLIENT:-0}
+      # Optional path prefix for a reverse proxy that routes by path on a single
+      # shared hostname/port (e.g. "/my-tier"), instead of by hostname or port.
+      # Reused for both Kestrel's bound URL and PublicWebBaseUrl. See
+      # docs/WEBCLIENT-POC.md.
+      BC_WEBCLIENT_PATHBASE: ${BC_WEBCLIENT_PATHBASE:-}
       SQL_SERVER: sql
       # .NET runtime tuning. Defaults are inherited from the entrypoint
       # (gcServer=1, TieredCompilation=0). These pass-throughs let us A/B
@@ -169,7 +185,7 @@ services:
       # Cronus license is used. No effect when unset.
       - ${BC_LICENSE_HOST_PATH:-/dev/null}:/bc/custom-license.bclicense:ro
     healthcheck:
-      test: test -f /tmp/bc-ready && curl -sf -o /dev/null -u BCRUNNER:Admin123! http://localhost:7048/BC/ODataV4/Company || exit 1
+      test: test -f /tmp/bc-ready && curl -sf -o /dev/null -u '${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}' http://localhost:7048/BC/ODataV4/Company || exit 1
       # 2s interval (was 15s, then 5s) so the healthy transition is seen within
       # ~2s of the entrypoint touching /tmp/bc-ready. With cold boots down to
       # ~30-80s (R2R Merkle seeding + fast downloads), a 5s interval was

--- a/docs/WEBCLIENT-POC.md
+++ b/docs/WEBCLIENT-POC.md
@@ -48,6 +48,27 @@ F5 keeps opening a port-less `http://localhost/?page=...` URL after enabling
 the web client on an existing setup, delete that file (or restart VS Code's
 AL services) to force a re-read.
 
+### Path-prefix reverse proxying
+
+Set `BC_WEBCLIENT_PATHBASE` (e.g. `/my-tier`) when a reverse proxy in front
+of the container routes by path on a single shared hostname/port instead of
+by hostname or port — the case where adding a hostname or a port per tier
+isn't an option:
+
+```bash
+BC_WEBCLIENT=1 BC_WEBCLIENT_PATHBASE=/my-tier docker compose up -d --wait
+```
+
+`start-webclient.sh` appends the prefix to the URL it writes into
+`hosting.json`. `HttpSysStub`'s `UrlStrippingStartupFilter` (shared with the
+NST) already strips path components off server addresses that Kestrel can't
+bind directly and calls `UsePathBase()` with the stripped path, so BC's own
+middleware — redirects (`Location: /SignIn?...`), asset URLs, `ReturnUrl` —
+routes correctly under the prefix without any further configuration. The
+entrypoint reuses the same prefix for `PublicWebBaseUrl` so the AL debugger's
+F5 launch URL matches. Leave it unset for the default root-path setup; it
+has no effect on the NST or on `BC_WEBCLIENT=0`.
+
 ## Architecture
 
 ```

--- a/examples/azure-pipelines/bc-test-from-source.yml
+++ b/examples/azure-pipelines/bc-test-from-source.yml
@@ -589,6 +589,12 @@ steps:
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" end PUBLISH
     displayName: 'Publish AL apps to BC'
 
+  # Always the websocket runner (scripts/run-tests.sh), not the reusable
+  # workflow's test_runner=auto hybrid split — that split depends on the
+  # altool/TestRunnerHub runner (BC 28+, opt-in), and this example is meant
+  # to work unmodified on every supported BC version. Copy from
+  # .github/workflows/bc-test-from-source.yml in bc-linux directly if you
+  # need the faster hybrid path and are pinned to BC 28+.
   - bash: |
       set -e
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" begin TESTS "Run AL tests"

--- a/examples/github-workflows/bc-test-from-source.yml
+++ b/examples/github-workflows/bc-test-from-source.yml
@@ -588,6 +588,12 @@ jobs:
           bash bc-linux/scripts/workflow-summary.sh count apps_compiled "$COMPILED_COUNT"
           bash bc-linux/scripts/workflow-summary.sh end PUBLISH
 
+      # Always the websocket runner (scripts/run-tests.sh), not the reusable
+      # workflow's test_runner=auto hybrid split — that split depends on the
+      # altool/TestRunnerHub runner (BC 28+, opt-in), and this example is
+      # meant to work unmodified on every supported BC version. Copy from
+      # .github/workflows/bc-test-from-source.yml in bc-linux directly if you
+      # need the faster hybrid path and are pinned to BC 28+.
       - name: Run AL tests
         working-directory: bc-linux
         run: |

--- a/scripts/bench-snapshot.sh
+++ b/scripts/bench-snapshot.sh
@@ -52,7 +52,7 @@ wait_odata() {
   local deadline=$(( $(date +%s) + 900 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
-         -u BCRUNNER:Admin123! "$ODATA_URL" 2>/dev/null)" = "200" ] && return 0
+         -u "${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}" "$ODATA_URL" 2>/dev/null)" = "200" ] && return 0
     sleep 1
   done
   return 1

--- a/scripts/check-example-drift.py
+++ b/scripts/check-example-drift.py
@@ -67,6 +67,15 @@ EXEMPT = {
     "scripts/run-tests-altool.py":
         "the altool runner is opt-in and BC 28+ only; the examples "
         "deliberately show the websocket runner, which works everywhere",
+    "scripts/run-tests-hybrid.py":
+        "test_runner=auto's hybrid split installs and probes the altool "
+        "runner (see the run-tests-altool.py exemption above) before "
+        "falling back; same reason, one level up — the examples "
+        "deliberately show only the universal websocket runner",
+    "scripts/classify-handler-codeunits.py":
+        "only used internally by run-tests-hybrid.py's static AL-source "
+        "scan (see that exemption above); not called directly by the "
+        "reusable workflow either",
     "scripts/discover-bc-versions.py":
         "version discovery drives bc-linux's own matrix; a consumer "
         "pipeline targets one version it chooses itself",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -855,18 +855,32 @@ else
     log_step "Cleared test framework global entries (will re-publish via dev endpoint)"
 fi
 
-# Service user for scripting/OData/dev endpoint (password hash for Admin123! with GUID 00000000-0000-0000-0000-000000000001)
-# Named BCRUNNER (not ADMIN) so tests can freely create/delete/disable an "ADMIN" user.
+# Service user for scripting/OData/dev endpoint/web client sign-in (SUPER access).
+# Username defaults to BCRUNNER (not ADMIN) so tests can freely create/delete/disable
+# an "ADMIN" user; override via BC_SERVER_USERNAME/BC_SERVER_PASSWORD (docker-compose.yml
+# passes these through — see the comment there). GUID 00000000-0000-0000-0000-000000000001.
+#
+# The stored password hash is a fixed placeholder, NOT a hash of BC_SERVER_PASSWORD —
+# NavUser.TryAuthenticate's hash check doesn't verify on Linux (the Windows hash format
+# doesn't port; StartupHook Patch #16b bypasses verification and always returns true),
+# so whatever the DB row holds is never compared against what the client sends. Any
+# password authenticates as this user once it exists with SUPER access; the [Password]
+# column only needs to be non-empty for the platform to treat the account as
+# NavUserPassword-eligible. That means BC_SERVER_PASSWORD is honored end-to-end (that
+# value really does work at every login surface) without needing to reproduce BC's
+# hash algorithm, which isn't documented anywhere outside the platform binaries.
 USER_GUID='00000000-0000-0000-0000-000000000001'
+BC_SERVER_USERNAME="${BC_SERVER_USERNAME:-BCRUNNER}"
+BC_SERVER_PASSWORD="${BC_SERVER_PASSWORD:-Admin123!}"
 PASSWORD_HASH='aXD91GRctWiXaqXeWbXhxQ==-V3'
 $SQLCMD_DB -Q "
-IF NOT EXISTS (SELECT 1 FROM [User] WHERE [User Name] = 'BCRUNNER')
+IF NOT EXISTS (SELECT 1 FROM [User] WHERE [User Name] = N'$BC_SERVER_USERNAME')
 BEGIN
     INSERT INTO [User] ([User Security ID], [User Name], [Full Name], [State], [Expiry Date],
         [Windows Security ID], [Change Password], [License Type], [Authentication Email],
         [Contact Email], [Exchange Identifier], [Application ID],
         [\$systemId], [\$systemCreatedAt], [\$systemCreatedBy], [\$systemModifiedAt], [\$systemModifiedBy])
-    VALUES ('$USER_GUID', N'BCRUNNER', N'BC Runner', 0, '2099-12-31', N'S-1-5-21-2074085148-119339936-2019613796-1001', 0, 0, N'', N'', N'',
+    VALUES ('$USER_GUID', N'$BC_SERVER_USERNAME', N'BC Runner', 0, '2099-12-31', N'S-1-5-21-2074085148-119339936-2019613796-1001', 0, 0, N'', N'', N'',
         '00000000-0000-0000-0000-000000000000',
         NEWID(), GETUTCDATE(), '$USER_GUID', GETUTCDATE(), '$USER_GUID');
     INSERT INTO [User Property] ([User Security ID], [Password], [Name Identifier],
@@ -909,7 +923,7 @@ BEGIN
         NEWID(), GETUTCDATE(), '$SVC_GUID', GETUTCDATE(), '$SVC_GUID');
 END
 " 2>/dev/null
-log_step "Database ready (BCRUNNER / Admin123!). Step 3 (DB setup): $(($(date +%s) - STEP3_START))s"
+log_step "Database ready ($BC_SERVER_USERNAME / $BC_SERVER_PASSWORD). Step 3 (DB setup): $(($(date +%s) - STEP3_START))s"
 
 # =============================================================================
 # Step 4: Start BC server in background, publish test runner, then wait
@@ -935,8 +949,21 @@ fi
 # empty the generated URL is the port-less http://localhost/?page=N, which lands on
 # port 80 and the debugger never binds a session. Override the default with
 # BC_WEBCLIENT_PUBLIC_URL when the host port differs (parallel instances).
+#
+# BC_WEBCLIENT_PATHBASE (e.g. "/my-prefix") mirrors the same prefix start-webclient.sh
+# gave Kestrel, so a reverse proxy that routes by path (one hostname/port shared by
+# several tiers) sees a matching PublicWebBaseUrl instead of one that points back
+# outside the prefix. See docs/WEBCLIENT-POC.md.
 if [ "${BC_WEBCLIENT:-0}" = "1" ]; then
-    PUBLIC_WEB_URL="${BC_WEBCLIENT_PUBLIC_URL:-http://localhost:${BC_WEBCLIENT_PORT:-8080}/}"
+    WEBCLIENT_PATHBASE="${BC_WEBCLIENT_PATHBASE:-}"
+    if [ -n "$WEBCLIENT_PATHBASE" ]; then
+        case "$WEBCLIENT_PATHBASE" in
+            /*) ;;
+            *) WEBCLIENT_PATHBASE="/$WEBCLIENT_PATHBASE" ;;
+        esac
+        WEBCLIENT_PATHBASE="${WEBCLIENT_PATHBASE%/}"
+    fi
+    PUBLIC_WEB_URL="${BC_WEBCLIENT_PUBLIC_URL:-http://localhost:${BC_WEBCLIENT_PORT:-8080}${WEBCLIENT_PATHBASE}/}"
     sed -i "s|PublicWebBaseUrl\" value=\"[^\"]*\"|PublicWebBaseUrl\" value=\"$PUBLIC_WEB_URL\"|" "$SERVICE_DIR/CustomSettings.config"
     log_step "PublicWebBaseUrl set to $PUBLIC_WEB_URL (AL debugger F5 / launch-mode browser URL)"
 fi
@@ -1329,7 +1356,7 @@ PYEOF
                 fi
 
                 HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 300 \
-                    -u "BCRUNNER:Admin123!" -X POST \
+                    -u "$BC_SERVER_USERNAME:$BC_SERVER_PASSWORD" -X POST \
                     -F "file=@$APP_FILE;type=application/octet-stream" \
                     "$DEV_URL/apps?SchemaUpdateMode=forcesync" 2>/dev/null)
                 echo "[entrypoint]   $APP_NAME $APP_VER: HTTP $HTTP"
@@ -1433,7 +1460,7 @@ PYEOF
                 # tenant deps), so we have to wipe stuck-published apps in
                 # SQL beforehand instead.
                 HTTP=$(curl -s -o /tmp/install-tenant.out -w "%{http_code}" --max-time 120 \
-                    -u "BCRUNNER:Admin123!" -X POST \
+                    -u "$BC_SERVER_USERNAME:$BC_SERVER_PASSWORD" -X POST \
                     -F "file=@$APP_PATH;type=application/octet-stream" \
                     "$DEV_URL/apps?SchemaUpdateMode=synchronize" 2>/dev/null)
                 # Treat "already deployed as Global" 422s as benign — they
@@ -1498,7 +1525,7 @@ PYEOF
                 [ -z "$APP_PATH" ] && continue
                 NAME=$(basename "$APP_PATH")
                 HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 120 \
-                    -u "BCRUNNER:Admin123!" -X POST \
+                    -u "$BC_SERVER_USERNAME:$BC_SERVER_PASSWORD" -X POST \
                     -F "file=@$APP_PATH;type=application/octet-stream" \
                     "$DEV_URL/apps?SchemaUpdateMode=synchronize" 2>/dev/null)
                 echo "[entrypoint]   $NAME: HTTP $HTTP"
@@ -1520,7 +1547,7 @@ PYEOF
                 fi
                 NAME=$(basename "$app")
                 HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 600 \
-                    -u "BCRUNNER:Admin123!" -X POST \
+                    -u "$BC_SERVER_USERNAME:$BC_SERVER_PASSWORD" -X POST \
                     -F "file=@$app;type=application/octet-stream" \
                     "$DEV_URL/apps?SchemaUpdateMode=forcesync" 2>/dev/null)
                 echo "[entrypoint]   $NAME: HTTP $HTTP"
@@ -1531,7 +1558,7 @@ PYEOF
         if [ -f /bc/testrunner/TestRunner.app ]; then
             echo "[entrypoint] Publishing Test Runner Extension..."
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
-                -u "BCRUNNER:Admin123!" -X POST \
+                -u "$BC_SERVER_USERNAME:$BC_SERVER_PASSWORD" -X POST \
                 -F "file=@/bc/testrunner/TestRunner.app;type=application/octet-stream" \
                 "$DEV_URL/apps?SchemaUpdateMode=synchronize" 2>&1)
             echo "[entrypoint] Test Runner Extension: HTTP $HTTP_CODE"

--- a/scripts/publish-app.sh
+++ b/scripts/publish-app.sh
@@ -45,7 +45,7 @@
 bc_publish_app() {
     local app="$1"
     local dev_url="${2:-http://localhost:7049/BC/dev}"
-    local auth="${3:-BCRUNNER:Admin123!}"
+    local auth="${3:-${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}}"
 
     if [ -z "$app" ]; then
         echo "bc_publish_app: missing required argument: <app-path>" >&2

--- a/scripts/run-tests-altool.py
+++ b/scripts/run-tests-altool.py
@@ -37,7 +37,10 @@ Usage:
 
 Authentication: the AL tool reads BC_SERVER_USERNAME / BC_SERVER_PASSWORD
 from the environment for --authentication UserPassword. This script sets
-them from --auth (default BCRUNNER:Admin123!, same as run-tests.sh).
+them from --auth, which itself defaults from those same two env vars
+(falling back to BCRUNNER:Admin123!, same as run-tests.sh) — so a container
+booted with a non-default BC_SERVER_USERNAME/BC_SERVER_PASSWORD (see
+docker-compose.yml) needs no extra flag here.
 
 --transport {cli,hub,auto}: 'cli' (default) shells out to `al runtests <id>`
 once per codeunit — this is the path validated above. 'auto' tries hub and
@@ -952,7 +955,11 @@ def main() -> int:
     ap.add_argument("--codeunit-range", default="", help="range filter, same syntax as run-tests.sh")
     ap.add_argument("--junit-output", default="", help="write JUnit XML to this path")
     ap.add_argument("--company", default="", help="company name (default: auto-detect via OData)")
-    ap.add_argument("--auth", default="BCRUNNER:Admin123!", help="user:pass (default matches run-tests.sh)")
+    ap.add_argument(
+        "--auth",
+        default=f"{os.environ.get('BC_SERVER_USERNAME', 'BCRUNNER')}:{os.environ.get('BC_SERVER_PASSWORD', 'Admin123!')}",
+        help="user:pass (default: BC_SERVER_USERNAME/BC_SERVER_PASSWORD env vars, falling back to BCRUNNER:Admin123!, matching run-tests.sh)",
+    )
     ap.add_argument("--server", default="http://localhost", help="BC server URL, no port (default http://localhost)")
     ap.add_argument("--server-instance", default="BC", help="NST instance name (default BC)")
     ap.add_argument("--port", type=int, default=7049, help="dev endpoint port (default 7049)")

--- a/scripts/run-tests-hybrid.py
+++ b/scripts/run-tests-hybrid.py
@@ -198,7 +198,10 @@ def main() -> int:
     ap.add_argument("--codeunit-range", default="", help="range filter, same syntax as run-tests.sh")
     ap.add_argument("--junit-output", default="", help="write merged JUnit XML to this path")
     ap.add_argument("--company", default="")
-    ap.add_argument("--auth", default="BCRUNNER:Admin123!")
+    ap.add_argument(
+        "--auth",
+        default=f"{os.environ.get('BC_SERVER_USERNAME', 'BCRUNNER')}:{os.environ.get('BC_SERVER_PASSWORD', 'Admin123!')}",
+    )
     ap.add_argument("--base-url", default="http://localhost:7048/BC")
     ap.add_argument("--dev-url", default="http://localhost:7049/BC/dev", help="passed to run-tests.sh (websocket)")
     ap.add_argument("--server", default="http://localhost", help="passed to run-tests-altool.py")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -36,7 +36,10 @@ unset CDPATH
 # === Configuration & CLI Parsing ===
 BASE_URL="http://localhost:7048/BC"
 DEV_URL="http://localhost:7049/BC/dev"
-AUTH="BCRUNNER:Admin123!"
+# Matches the container's login (BC_SERVER_USERNAME/BC_SERVER_PASSWORD in
+# docker-compose.yml — see scripts/entrypoint.sh); override with --auth if
+# the container was booted with a non-default login.
+AUTH="${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}"
 COMPANY=""
 CODEUNIT_RANGE=""
 APP_FILE=""

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -542,7 +542,7 @@ _du_store() { du -sh "$1" 2>/dev/null | cut -f1 || echo "?"; }
 _bc_odata() {
   local code
   code=$(docker compose exec -T bc curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
-    -u BCRUNNER:Admin123! http://localhost:7048/BC/ODataV4/Company 2>/tmp/snapshot-odata.err) || true
+    -u "${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}" http://localhost:7048/BC/ODataV4/Company 2>/tmp/snapshot-odata.err) || true
   printf '%s' "${code:-000}"
 }
 
@@ -552,7 +552,7 @@ _odata_diagnosis() {
   log "  docker compose exec stderr: $(head -c 300 /tmp/snapshot-odata.err 2>/dev/null | tr '\n' ' ')"
   log "  bc container: $(docker compose ps --format '{{.Name}} {{.State}} {{.Health}}' bc 2>/dev/null | head -1)"
   log "  host port 7048: $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
-        -u BCRUNNER:Admin123! http://localhost:7048/BC/ODataV4/Company 2>/dev/null || echo unreachable)"
+        -u "${BC_SERVER_USERNAME:-BCRUNNER}:${BC_SERVER_PASSWORD:-Admin123!}" http://localhost:7048/BC/ODataV4/Company 2>/dev/null || echo unreachable)"
   # BC writes multi-line diagnostic blocks -- a stack trace, then ProcessId,
   # Tag, ThreadId, CounterInformation and so on. A plain `--tail 12` therefore
   # lands in the MIDDLE of one and shows nothing but frame lines and empty

--- a/scripts/start-webclient.sh
+++ b/scripts/start-webclient.sh
@@ -18,6 +18,23 @@ ARTIFACTS="${ARTIFACTS:-/bc/artifacts}"
 WEBCLIENT_DIR="${WEBCLIENT_DIR:-/bc/webclient}"
 HOOK_DLL="/bc/webclient-hook/WebClientHook.dll"
 
+# Optional path-prefix support for reverse proxies that route by path
+# (single hostname/port, e.g. https://host:port/my-tier) rather than by
+# hostname or port. HttpSysStub's UrlStrippingStartupFilter already strips
+# a path component off the server address and calls UsePathBase() with it
+# (see src/stubs/HttpSysStub/HttpSysStub.cs) — this just gives that a
+# documented, first-class way in from docker compose. Normalize to a
+# leading slash / no trailing slash; HttpSysStub trims a trailing slash
+# itself, but the leading slash is required for Uri.AbsolutePath parsing.
+PATHBASE="${BC_WEBCLIENT_PATHBASE:-}"
+if [ -n "$PATHBASE" ]; then
+    case "$PATHBASE" in
+        /*) ;;
+        *) PATHBASE="/$PATHBASE" ;;
+    esac
+    PATHBASE="${PATHBASE%/}"
+fi
+
 # Locate the WebPublish layout in the platform artifact
 WEBPUBLISH=$(find "$ARTIFACTS/platform/WebClient" -maxdepth 5 -type d -name WebPublish 2>/dev/null | head -1)
 if [ -z "$WEBPUBLISH" ]; then
@@ -53,13 +70,16 @@ done)
 [ -e "$WEBCLIENT_DIR/wwwroot/Resources/Fonts" ] || ln -s fonts "$WEBCLIENT_DIR/wwwroot/Resources/Fonts"
 
 # Point the web client at the local NST (NavUserPassword over ws://localhost:7085)
-python3 - "$WEBCLIENT_DIR" "$PORT" <<'PYEOF'
+python3 - "$WEBCLIENT_DIR" "$PORT" "$PATHBASE" <<'PYEOF'
 import json, sys
 base = sys.argv[1]
 port = sys.argv[2]
+pathbase = sys.argv[3]
 
-# hosting.json wins over ASPNETCORE_URLS (the app calls UseUrls with it)
-json.dump({"urls": f"http://*:{port}"}, open(f"{base}/hosting.json", "w"), indent=2)
+# hosting.json wins over ASPNETCORE_URLS (the app calls UseUrls with it).
+# The path component (if any) is stripped back off by HttpSysStub's
+# UrlStrippingStartupFilter, which calls UsePathBase() with it.
+json.dump({"urls": f"http://*:{port}{pathbase}"}, open(f"{base}/hosting.json", "w"), indent=2)
 
 p = f"{base}/navsettings.json"
 d = json.load(open(p, encoding="utf-8-sig"))
@@ -81,7 +101,7 @@ json.dump(d, open(p, "w"), indent=2)
 print("[webclient] navsettings.json + runtimeconfig.json patched")
 PYEOF
 
-echo "[webclient] Starting Prod.Client.WebCoreApp on http://0.0.0.0:$PORT (NST: localhost:7085, auth: NavUserPassword)"
+echo "[webclient] Starting Prod.Client.WebCoreApp on http://0.0.0.0:$PORT${PATHBASE} (NST: localhost:7085, auth: NavUserPassword)"
 cd "$WEBCLIENT_DIR"
 # DOTNET_STARTUP_HOOKS: replace the NST hook with the web-client-specific one.
 # The NST hook contains patches that assume the NST process and must not run here.


### PR DESCRIPTION
## Summary

- Adds `BC_SERVER_USERNAME` / `BC_SERVER_PASSWORD` env vars to `docker-compose.yml`, so the login the entrypoint creates (`BCRUNNER` / `Admin123!` by default) can be renamed instead of being hardcoded in `entrypoint.sh`'s SQL and in the container healthcheck.
- The stored password is a fixed placeholder in the database either way — `NavUser.TryAuthenticate` doesn't check the password hash on Linux (StartupHook Patch #16b bypasses it, since the Windows hash format doesn't work there), so any password already logs in as an existing user with SUPER access. `BC_SERVER_PASSWORD` still works end-to-end because that's genuinely the value that gets typed or passed everywhere — it just isn't stored as a real hash. I documented this clearly in the code comments so it doesn't look like a bug later.
- `run-tests.sh`, `publish-app.sh`, `run-tests-altool.py`, and `run-tests-hybrid.py` now default their `--auth` from the same two env vars, so a container started with a custom login doesn't need `--auth` passed on every call.
- Adds `BC_WEBCLIENT_PATHBASE` for reverse proxies that route by path on one shared hostname/port instead of by hostname or port. `HttpSysStub` already supports this (`UrlStrippingStartupFilter` strips a path off the server address and calls `UsePathBase()` with it) — this just gives it a documented, first-class way in from `docker compose`, instead of needing to patch `start-webclient.sh` or smuggle a path through the port variable.

Fixes #31, fixes #29.

## Test plan

- [x] `bash -n` on every changed shell script
- [x] `python3 -m ast` parse check on the two changed Python scripts
- [x] `docker compose config` with default env vars, confirming the healthcheck and environment block interpolate to `BCRUNNER` / `Admin123!`
- [x] `docker compose config` with `BC_SERVER_USERNAME`, `BC_SERVER_PASSWORD` (including a password containing a colon), and `BC_WEBCLIENT_PATHBASE` set, confirming correct interpolation
- [ ] Full container boot with a custom `BC_SERVER_USERNAME`/`BC_SERVER_PASSWORD`, confirming login and `run-tests.sh` both work end-to-end (not run in this environment — worth doing before merge)
- [ ] Web client boot with `BC_WEBCLIENT_PATHBASE` set behind a real reverse proxy (not run in this environment)