### PR TITLE
webclient: add BC_WEBCLIENT_REQUIRE_SSL for proxy-terminated TLS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,10 @@ services:
       # Reused for both Kestrel's bound URL and PublicWebBaseUrl. See
       # docs/WEBCLIENT-POC.md.
       BC_WEBCLIENT_PATHBASE: ${BC_WEBCLIENT_PATHBASE:-}
+      # Set to 1 when a reverse proxy in front of the container terminates TLS,
+      # so the web client emits https:// in its redirects instead of http://.
+      # See docs/WEBCLIENT-POC.md.
+      BC_WEBCLIENT_REQUIRE_SSL: ${BC_WEBCLIENT_REQUIRE_SSL:-}
       SQL_SERVER: sql
       # .NET runtime tuning. Defaults are inherited from the entrypoint
       # (gcServer=1, TieredCompilation=0). These pass-throughs let us A/B

--- a/docs/WEBCLIENT-POC.md
+++ b/docs/WEBCLIENT-POC.md
@@ -69,6 +69,24 @@ entrypoint reuses the same prefix for `PublicWebBaseUrl` so the AL debugger's
 F5 launch URL matches. Leave it unset for the default root-path setup; it
 has no effect on the NST or on `BC_WEBCLIENT=0`.
 
+### TLS terminated by the proxy
+
+Set `BC_WEBCLIENT_REQUIRE_SSL=1` when that reverse proxy also terminates TLS.
+The web client speaks plain HTTP and builds its redirects from its own scheme,
+so without it the sign-in redirect comes back as
+`Location: http://<public-host>:<port>/SignIn?...`. The browser then follows
+that in cleartext against a TLS-only port and the request is reset
+(`ERR_CONNECTION_RESET`). The flag flips `RequireSsl` in `navsettings.json`, so
+BC emits `https://` and marks its session cookies `Secure`. It does not change
+how the client reaches the NST - that hop stays plain `ws://localhost:7085`
+(`ServerHttps` is unaffected). Leave it unset for direct `http://localhost`
+access.
+
+```bash
+BC_WEBCLIENT=1 BC_WEBCLIENT_PATHBASE=/my-tier BC_WEBCLIENT_REQUIRE_SSL=1 \
+  docker compose up -d --wait
+```
+
 ## Architecture
 
 ```

--- a/scripts/start-webclient.sh
+++ b/scripts/start-webclient.sh
@@ -35,6 +35,18 @@ if [ -n "$PATHBASE" ]; then
     PATHBASE="${PATHBASE%/}"
 fi
 
+# Optional: tell the web client it is reached over HTTPS even though it speaks
+# plain HTTP itself. Needed when TLS is terminated by a reverse proxy in front
+# of the container: without it the client builds its redirects from its own
+# scheme and emits "Location: http://<public-host>/SignIn", which the browser
+# then follows in cleartext against a TLS-only port. Also makes BC mark its
+# session cookies Secure. Off by default (direct http://localhost access).
+REQUIRE_SSL="${BC_WEBCLIENT_REQUIRE_SSL:-false}"
+case "$REQUIRE_SSL" in
+    1|true|True|TRUE|yes) REQUIRE_SSL="true" ;;
+    *) REQUIRE_SSL="false" ;;
+esac
+
 # Locate the WebPublish layout in the platform artifact
 WEBPUBLISH=$(find "$ARTIFACTS/platform/WebClient" -maxdepth 5 -type d -name WebPublish 2>/dev/null | head -1)
 if [ -z "$WEBPUBLISH" ]; then
@@ -70,11 +82,12 @@ done)
 [ -e "$WEBCLIENT_DIR/wwwroot/Resources/Fonts" ] || ln -s fonts "$WEBCLIENT_DIR/wwwroot/Resources/Fonts"
 
 # Point the web client at the local NST (NavUserPassword over ws://localhost:7085)
-python3 - "$WEBCLIENT_DIR" "$PORT" "$PATHBASE" <<'PYEOF'
+python3 - "$WEBCLIENT_DIR" "$PORT" "$PATHBASE" "$REQUIRE_SSL" <<'PYEOF'
 import json, sys
 base = sys.argv[1]
 port = sys.argv[2]
 pathbase = sys.argv[3]
+require_ssl = sys.argv[4]
 
 # hosting.json wins over ASPNETCORE_URLS (the app calls UseUrls with it).
 # The path component (if any) is stripped back off by HttpSysStub's
@@ -88,7 +101,7 @@ n["Server"] = "localhost"
 n["ServerInstance"] = "BC"
 n["ClientServicesPort"] = "7085"
 n["ClientServicesCredentialType"] = "NavUserPassword"
-n["RequireSsl"] = "false"
+n["RequireSsl"] = require_ssl
 n["ServerHttps"] = False
 n["AuthenticateServer"] = "false"
 json.dump(d, open(p, "w"), indent=2)


### PR DESCRIPTION
Fixes #33.

Behind a TLS-terminating reverse proxy the web client emits `Location: http://<public-host>/SignIn?...` because it speaks plain HTTP and derives the scheme from its own address. The browser follows that in cleartext against a TLS-only port and the request is reset.

`navsettings.json`'s `RequireSsl` is what controls this, but it is hardcoded to `"false"` in `start-webclient.sh`. This makes it configurable, same shape as `BC_WEBCLIENT_PATHBASE` from #32 - the two go together, since a path-prefix proxy is normally also the one terminating TLS.

**Behaviour**
- default unchanged (`false`): direct `http://localhost:8080` access behaves exactly as before
- accepts `1`/`true`/`yes`, anything else is `false`
- `ServerHttps` deliberately untouched - the hop to the NST stays plain `ws://localhost:7085`
- BC additionally marks its session cookies `Secure`, which is correct in that topology

**Verified** on BC 27.5 (w1) behind Traefik: without the flag the redirect is `http://` and the browser gets `ERR_CONNECTION_RESET`; with it the redirect is `https://` and sign-in completes.

Also documented in `docs/WEBCLIENT-POC.md` under the path-prefix section, and passed through in `docker-compose.yml`.