### PR TITLE
Make NavUserPassword authentication work correctly on Linux

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -1158,6 +1158,14 @@ jobs:
           ./scripts/wait-for-bc-healthy.sh ${{ inputs.health_timeout_minutes }}
           bash scripts/workflow-summary.sh end BC_BOOT
 
+      # Run on every supported/preview version so client-services wire-format
+      # changes fail here instead of silently weakening authentication. This
+      # must run before the positive-only publish/smoke path: the former
+      # Patch #16b made every later step green even with a wrong password.
+      - name: Verify NavUserPassword authentication
+        working-directory: bc-linux
+        run: ./scripts/test-authentication.sh
+
       # ─── Phase 7: publish compiled apps to the now-running BC ────────
       - name: Publish AL apps to BC
         env:

--- a/MICROSOFT-FEEDBACK.md
+++ b/MICROSOFT-FEEDBACK.md
@@ -265,7 +265,14 @@ and would never be set in production Windows BC deployments.
 | #21 (NavOpenTaskPageAction.ShowForm) | No-ops `ShowForm` so headless test sessions don't crash on task page opens | `DisableUIRendering=true` (already implied by headless mode but currently not enforced) |
 | #22 (AzureADGraphQuery..ctor) | No-ops the constructor that pulls in MSAL Windows credential APIs | `DisableAzureADGraphIntegration=true` |
 | #23 (OpenXml WordDocPictureMerger) | Fixes a recursion bug in Microsoft's Word merger | (Not a flag — this is a real bug in shipped code, would just want it fixed) |
-| #16b (NavUser.TryAuthenticate) | Bypasses password hash verification for the bc-linux service user | `AllowPasswordlessSandboxAuth=true` (only valid in sandbox mode) |
+
+Patch #16b is no longer present. Inspection of BC 28.4 showed that Microsoft's
+V3 derivation and `NavUser.TryAuthenticate` implementation already run correctly
+on Linux. The repository's fixed database value only represented the default
+`Admin123!` password, while custom `BC_SERVER_PASSWORD` values did not update it;
+the unconditional hook had hidden that bootstrap bug. The entrypoint now creates
+the genuine V3 value and leaves Microsoft's verifier unchanged, so no Microsoft
+passwordless-authentication flag is requested.
 
 The Cecil-related patches (#14, #15, #15a, #15b, CheckFileName) are
 trickier — they fix Cecil bugs that Microsoft would have to fix in

--- a/README.md
+++ b/README.md
@@ -122,13 +122,11 @@ curl -sf -u MYUSER:MyP@ss1! http://localhost:7048/BC/ODataV4/Company
 The scripts in `scripts/` (`run-tests.sh`, `run-tests-altool.py`,
 `run-tests-hybrid.py`, `publish-app.sh`, etc.) pick the same two env vars up
 automatically, so no `--auth` flag is needed once the container was booted
-with them. Password verification is not actually enforced on Linux —
-`NavUser.TryAuthenticate`'s hash check doesn't port from Windows, so
-StartupHook Patch #16b bypasses it and any password authenticates as an
-existing, enabled user. `BC_SERVER_PASSWORD` still works end-to-end (that
-exact value is what you type/pass), it just isn't a real access control —
-this is a local dev/CI sandbox account, not something to expose to an
-untrusted network.
+with them. The entrypoint derives Microsoft's V3 password representation from
+`BC_SERVER_PASSWORD`, and the unmodified Business Central verifier enforces it:
+wrong passwords and disabled, expired, or nonexistent users are rejected.
+These remain local dev/CI credentials; do not expose the container's ports to
+an untrusted network.
 
 ### Web client (browser UI)
 
@@ -343,6 +341,8 @@ BC_DEV_PORT=17049 docker compose up -d
 | `BC_API_PORT`     | `7052`           | API v2.0 port                                                                |
 | `BC_MGMT_PORT`    | `7045`           | Management endpoint port                                                     |
 | `BC_CLIENT_PORT`  | `7085`           | WebSocket client services port (used by `run-tests.sh`)                      |
+| `BC_SERVER_USERNAME` | `BCRUNNER`    | NavUserPassword service user created with SUPER access                       |
+| `BC_SERVER_PASSWORD` | `Admin123!`   | Enforced password used to generate the service user's Microsoft V3 value     |
 | `BC_LICENSE_HOST_PATH` | unset       | Optional host path to a `.bclicense` file. Mounted into bc + sql containers and imported INSTEAD of the default Cronus license. See "Custom license" below. |
 | `BC_LICENSE_FILE` | unset            | Path INSIDE the container of the license file to import. Set to `/bc/custom-license.bclicense` together with `BC_LICENSE_HOST_PATH`. |
 | `BC_SQL_IMAGE`    | GHCR mirror      | SQL Server image. See "SQL Server image" below.                              |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,12 +104,10 @@ services:
       # The NavUserPassword login the entrypoint creates for OData/SOAP/dev-endpoint/
       # web-client sign-in (SUPER access). Defaults preserve the long-documented
       # BCRUNNER/Admin123! pair; override both to change the account name, e.g. when
-      # a consumer's own tooling expects a specific username. Note the *password*
-      # here is cosmetic, not enforced: NavUser.TryAuthenticate's hash check doesn't
-      # verify on Linux (StartupHook Patch #16b bypasses it and always succeeds), so
-      # ANY password authenticates as this user — see scripts/entrypoint.sh. This is
-      # a local dev/CI sandbox account, not a security boundary; don't expose these
-      # ports to an untrusted network.
+      # a consumer's own tooling expects a specific username. The entrypoint derives
+      # Microsoft's V3 representation from this password and Business Central's
+      # original NavUser.TryAuthenticate implementation enforces it. This is still a
+      # local dev/CI sandbox account; don't expose these ports to an untrusted network.
       BC_SERVER_USERNAME: ${BC_SERVER_USERNAME:-BCRUNNER}
       BC_SERVER_PASSWORD: ${BC_SERVER_PASSWORD:-Admin123!}
       BC_CLEAR_ALL_APPS: ${BC_CLEAR_ALL_APPS:-false}

--- a/examples/azure-pipelines/bc-test-from-source.yml
+++ b/examples/azure-pipelines/bc-test-from-source.yml
@@ -562,6 +562,15 @@ steps:
 
   - bash: |
       set -e
+      cd "$(Agent.BuildDirectory)/bc-linux"
+      # Run before the positive-only publish/smoke path below, same as the
+      # reusable workflow: this is what catches a client-services wire-format
+      # regression instead of every later step passing with a wrong password.
+      ./scripts/test-authentication.sh
+    displayName: 'Verify NavUserPassword authentication'
+
+  - bash: |
+      set -e
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" begin PUBLISH "Publish AL apps"
       AUTH="BCRUNNER:Admin123!"
       DEV="http://localhost:7049/BC/dev"

--- a/examples/github-workflows/bc-test-from-source.yml
+++ b/examples/github-workflows/bc-test-from-source.yml
@@ -558,6 +558,13 @@ jobs:
           ./scripts/wait-for-bc-healthy.sh 30
           bash scripts/workflow-summary.sh end BC_BOOT
 
+      # Run before the positive-only publish/smoke path below, same as the
+      # reusable workflow: this is what catches a client-services wire-format
+      # regression instead of every later step passing with a wrong password.
+      - name: Verify NavUserPassword authentication
+        working-directory: bc-linux
+        run: ./scripts/test-authentication.sh
+
       # ─── Phase 7: publish compiled apps to the now-running BC ────────
       - name: Publish AL apps to BC
         env:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -859,22 +859,24 @@ fi
 # Username defaults to BCRUNNER (not ADMIN) so tests can freely create/delete/disable
 # an "ADMIN" user; override via BC_SERVER_USERNAME/BC_SERVER_PASSWORD (docker-compose.yml
 # passes these through — see the comment there). GUID 00000000-0000-0000-0000-000000000001.
-#
-# The stored password hash is a fixed placeholder, NOT a hash of BC_SERVER_PASSWORD —
-# NavUser.TryAuthenticate's hash check doesn't verify on Linux (the Windows hash format
-# doesn't port; StartupHook Patch #16b bypasses verification and always returns true),
-# so whatever the DB row holds is never compared against what the client sends. Any
-# password authenticates as this user once it exists with SUPER access; the [Password]
-# column only needs to be non-empty for the platform to treat the account as
-# NavUserPassword-eligible. That means BC_SERVER_PASSWORD is honored end-to-end (that
-# value really does work at every login surface) without needing to reproduce BC's
-# hash algorithm, which isn't documented anywhere outside the platform binaries.
+# The helper reads the password from stdin and creates Microsoft's V3 representation;
+# plaintext is never passed on argv, written to SQL, or logged.
 USER_GUID='00000000-0000-0000-0000-000000000001'
 BC_SERVER_USERNAME="${BC_SERVER_USERNAME:-BCRUNNER}"
 BC_SERVER_PASSWORD="${BC_SERVER_PASSWORD:-Admin123!}"
-PASSWORD_HASH='aXD91GRctWiXaqXeWbXhxQ==-V3'
-$SQLCMD_DB -Q "
-IF NOT EXISTS (SELECT 1 FROM [User] WHERE [User Name] = N'$BC_SERVER_USERNAME')
+if [ -z "$BC_SERVER_PASSWORD" ]; then
+    log_step "ERROR: BC_SERVER_PASSWORD must not be empty"
+    exit 1
+fi
+PASSWORD_HASH=$(printf '%s' "$BC_SERVER_PASSWORD" | \
+    env DOTNET_STARTUP_HOOKS= /bc/tools/NavUserPasswordInspector/NavUserPasswordInspector generate \
+        --user-security-id "$USER_GUID")
+if [[ ! "$PASSWORD_HASH" =~ ^[A-Za-z0-9+/]{22}==-V3$ ]]; then
+    log_step "ERROR: password generator returned an invalid V3 representation"
+    exit 1
+fi
+$SQLCMD_DB -b -Q "
+IF NOT EXISTS (SELECT 1 FROM [User] WHERE [User Security ID] = '$USER_GUID')
 BEGIN
     INSERT INTO [User] ([User Security ID], [User Name], [Full Name], [State], [Expiry Date],
         [Windows Security ID], [Change Password], [License Type], [Authentication Email],
@@ -883,18 +885,43 @@ BEGIN
     VALUES ('$USER_GUID', N'$BC_SERVER_USERNAME', N'BC Runner', 0, '2099-12-31', N'S-1-5-21-2074085148-119339936-2019613796-1001', 0, 0, N'', N'', N'',
         '00000000-0000-0000-0000-000000000000',
         NEWID(), GETUTCDATE(), '$USER_GUID', GETUTCDATE(), '$USER_GUID');
+END
+ELSE
+BEGIN
+    UPDATE [User]
+    SET [User Name] = N'$BC_SERVER_USERNAME', [\$systemModifiedAt] = GETUTCDATE(),
+        [\$systemModifiedBy] = '$USER_GUID'
+    WHERE [User Security ID] = '$USER_GUID';
+END;
+
+IF NOT EXISTS (SELECT 1 FROM [User Property] WHERE [User Security ID] = '$USER_GUID')
+BEGIN
     INSERT INTO [User Property] ([User Security ID], [Password], [Name Identifier],
         [Authentication Key], [WebServices Key], [WebServices Key Expiry Date],
         [Authentication Object ID], [Directory Role ID], [Telemetry User ID],
         [\$systemId], [\$systemCreatedAt], [\$systemCreatedBy], [\$systemModifiedAt], [\$systemModifiedBy])
     VALUES ('$USER_GUID', N'$PASSWORD_HASH', N'', N'', N'', '1753-01-01', N'', N'', '$USER_GUID',
         NEWID(), GETUTCDATE(), '$USER_GUID', GETUTCDATE(), '$USER_GUID');
+END
+ELSE
+BEGIN
+    UPDATE [User Property]
+    SET [Password] = N'$PASSWORD_HASH', [\$systemModifiedAt] = GETUTCDATE(),
+        [\$systemModifiedBy] = '$USER_GUID'
+    WHERE [User Security ID] = '$USER_GUID';
+END;
+
+IF NOT EXISTS (SELECT 1 FROM [Access Control]
+               WHERE [User Security ID] = '$USER_GUID' AND [Role ID] = N'SUPER'
+                 AND [Company Name] = N'' AND [Scope] = 0
+                 AND [App ID] = '00000000-0000-0000-0000-000000000000')
+BEGIN
     INSERT INTO [Access Control] ([User Security ID], [Role ID], [Company Name], [Scope], [App ID],
         [\$systemId], [\$systemCreatedAt], [\$systemCreatedBy], [\$systemModifiedAt], [\$systemModifiedBy])
     VALUES ('$USER_GUID', N'SUPER', N'', 0, '00000000-0000-0000-0000-000000000000',
         NEWID(), GETUTCDATE(), '$USER_GUID', GETUTCDATE(), '$USER_GUID');
 END
-" 2>/dev/null
+"
 
 # Background SUPER user — safety net so tests can freely disable/delete users
 # without violating the "at least one enabled SUPER user" platform constraint.
@@ -923,7 +950,7 @@ BEGIN
         NEWID(), GETUTCDATE(), '$SVC_GUID', GETUTCDATE(), '$SVC_GUID');
 END
 " 2>/dev/null
-log_step "Database ready ($BC_SERVER_USERNAME / $BC_SERVER_PASSWORD). Step 3 (DB setup): $(($(date +%s) - STEP3_START))s"
+log_step "Database ready ($BC_SERVER_USERNAME). Step 3 (DB setup): $(($(date +%s) - STEP3_START))s"
 
 # =============================================================================
 # Step 4: Start BC server in background, publish test runner, then wait

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -630,13 +630,14 @@ if [ "$USE_DOCKER_EXEC" = "true" ]; then
     if [ -n "$JUNIT_OUTPUT" ]; then
         JUNIT_FLAGS+=(--junit-output /tmp/junit-result.xml)
     fi
-    ( cd "$REPO_DIR" && docker compose exec -T bc dotnet /bc/tools/TestRunner/TestRunner.dll \
+    ( cd "$REPO_DIR" && printf '%s' "$AUTH_PASS" | docker compose exec -T bc \
+        env DOTNET_STARTUP_HOOKS= dotnet /bc/tools/TestRunner/TestRunner.dll \
         --verbose \
         --host "localhost:7085" \
         --odata-host "localhost:7052" \
         --company "$COMPANY" \
         --user "$AUTH_USER" \
-        --password "$AUTH_PASS" \
+        --password-stdin \
         --suite "DEFAULT" \
         --num-codeunits "$NUM_CODEUNITS" \
         --timeout "$TIMEOUT_MIN" \
@@ -660,13 +661,13 @@ elif [ -n "$HOST_PREBUILT" ]; then
     if [ -n "$JUNIT_OUTPUT" ]; then
         JUNIT_FLAGS+=(--junit-output "$JUNIT_OUTPUT")
     fi
-    dotnet "$HOST_PREBUILT" \
+    printf '%s' "$AUTH_PASS" | dotnet "$HOST_PREBUILT" \
         --verbose \
         --host "$WS_HOST" \
         --odata-host "$ODATA_HOST" \
         --company "$COMPANY" \
         --user "$AUTH_USER" \
-        --password "$AUTH_PASS" \
+        --password-stdin \
         --suite "DEFAULT" \
         --num-codeunits "$NUM_CODEUNITS" \
         --timeout "$TIMEOUT_MIN" \
@@ -679,13 +680,13 @@ elif command -v dotnet >/dev/null 2>&1; then
     if [ -n "$JUNIT_OUTPUT" ]; then
         JUNIT_FLAGS+=(--junit-output "$JUNIT_OUTPUT")
     fi
-    dotnet run --project "$REPO_DIR/tools/TestRunner" -v q -- \
+    printf '%s' "$AUTH_PASS" | dotnet run --project "$REPO_DIR/tools/TestRunner" -v q -- \
         --verbose \
         --host "$WS_HOST" \
         --odata-host "$ODATA_HOST" \
         --company "$COMPANY" \
         --user "$AUTH_USER" \
-        --password "$AUTH_PASS" \
+        --password-stdin \
         --suite "DEFAULT" \
         --num-codeunits "$NUM_CODEUNITS" \
         --timeout "$TIMEOUT_MIN" \

--- a/scripts/test-authentication.sh
+++ b/scripts/test-authentication.sh
@@ -41,6 +41,30 @@ expect_rejected() {
     esac
 }
 
+# The disabled/expired-user assertions below insert or modify [User]/
+# [User Property] rows directly via SQL while NST is already running, not
+# through BC's own user-management API. BC's user cache can lag that
+# out-of-band write by a second or two, so the very next request can 401 as
+# "unknown user" even though the row is already correct in the database —
+# observed intermittently in CI (a freshly-inserted enabled user 401ing, or a
+# just-disabled user still authenticating). Retry until the class of
+# response we expect shows up, or the deadline passes and we report
+# whatever the last attempt got — a real auth bug still fails the test, a
+# stale cache just costs a few seconds.
+poll_status_class() {
+    local class=$1 url=$2 username=$3 password=$4 output=$5
+    local attempts=10 delay=1 status
+    for ((i = 1; i <= attempts; i++)); do
+        status=$(status_with_basic_auth "$url" "$username" "$password" "$output")
+        case "$class:$status" in
+            success:2??) echo "$status"; return ;;
+            rejected:401|rejected:403) echo "$status"; return ;;
+        esac
+        [ "$i" -lt "$attempts" ] && sleep "$delay"
+    done
+    echo "$status"
+}
+
 tmp_dir=$(mktemp -d)
 DISABLED_GUID='00000000-0000-0000-0000-000000000101'
 EXPIRED_GUID='00000000-0000-0000-0000-000000000102'
@@ -131,8 +155,8 @@ INSERT INTO [Access Control] ([User Security ID],[Role ID],[Company Name],[Scope
 ('$EXPIRED_GUID',N'SUPER',N'',0,'00000000-0000-0000-0000-000000000000',NEWID(),GETUTCDATE(),'$EXPIRED_GUID',GETUTCDATE(),'$EXPIRED_GUID');
 " >/dev/null
 
-disabled_before=$(status_with_basic_auth "$ODATA_URL" "$DISABLED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled-before")
-expired_before=$(status_with_basic_auth "$ODATA_URL" "$EXPIRED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/expired-before")
+disabled_before=$(poll_status_class success "$ODATA_URL" "$DISABLED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled-before")
+expired_before=$(poll_status_class success "$ODATA_URL" "$EXPIRED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/expired-before")
 expect_success "disabled test user before disabling" "$disabled_before"
 expect_success "expired test user before expiry" "$expired_before"
 
@@ -147,8 +171,8 @@ SET [User Name] = N'$EXPIRED_USER', [Expiry Date] = '2000-01-01',
 WHERE [User Security ID] = '$EXPIRED_GUID';
 " >/dev/null
 
-disabled=$(status_with_basic_auth "$ODATA_URL" "$DISABLED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled")
-expired=$(status_with_basic_auth "$ODATA_URL" "$EXPIRED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/expired")
+disabled=$(poll_status_class rejected "$ODATA_URL" "$DISABLED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled")
+expired=$(poll_status_class rejected "$ODATA_URL" "$EXPIRED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/expired")
 expect_rejected "disabled user" "$disabled"
 expect_rejected "expired user" "$expired"
 

--- a/scripts/test-authentication.sh
+++ b/scripts/test-authentication.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# BC NavUserPassword regression: every positive assertion is paired with a
+# negative assertion so an unconditional authentication bypass cannot pass.
+set -euo pipefail
+
+BC_SERVER_USERNAME="${BC_SERVER_USERNAME:-BCRUNNER}"
+BC_SERVER_PASSWORD="${BC_SERVER_PASSWORD:-Admin123!}"
+BC_ODATA_PORT="${BC_ODATA_PORT:-7048}"
+BC_DEV_PORT="${BC_DEV_PORT:-7049}"
+COMPOSE=(docker compose)
+
+if [ -z "$BC_SERVER_PASSWORD" ]; then
+    echo "authentication test: BC_SERVER_PASSWORD must not be empty" >&2
+    exit 1
+fi
+
+WRONG_PASSWORD="${BC_SERVER_PASSWORD}__bc_auth_regression_wrong__"
+
+ODATA_URL="http://127.0.0.1:${BC_ODATA_PORT}/BC/ODataV4/Company"
+DEV_URL="http://127.0.0.1:${BC_DEV_PORT}/BC/dev/packages?publisher=Microsoft&appName=System&appVersion=0.0.0.0"
+
+status_with_basic_auth() {
+    local url=$1 username=$2 password=$3 output=$4
+    curl --silent --show-error --output "$output" --write-out '%{http_code}' \
+        --user "$username:$password" "$url"
+}
+
+expect_success() {
+    local label=$1 status=$2
+    case "$status" in
+        2??) printf 'PASS  %-38s HTTP %s\n' "$label" "$status" ;;
+        *) echo "FAIL  $label expected HTTP success, got $status" >&2; exit 1 ;;
+    esac
+}
+
+expect_rejected() {
+    local label=$1 status=$2
+    case "$status" in
+        401|403) printf 'PASS  %-38s HTTP %s\n' "$label" "$status" ;;
+        *) echo "FAIL  $label expected authentication rejection, got $status" >&2; exit 1 ;;
+    esac
+}
+
+tmp_dir=$(mktemp -d)
+DISABLED_GUID='00000000-0000-0000-0000-000000000101'
+EXPIRED_GUID='00000000-0000-0000-0000-000000000102'
+DISABLED_USER="${BC_SERVER_USERNAME}_AUTH_DISABLED"
+EXPIRED_USER="${BC_SERVER_USERNAME}_AUTH_EXPIRED"
+DISABLED_USER_BEFORE="${DISABLED_USER}_BEFORE"
+EXPIRED_USER_BEFORE="${EXPIRED_USER}_BEFORE"
+
+sql() {
+    "${COMPOSE[@]}" exec -T bc /opt/mssql-tools18/bin/sqlcmd \
+        -S "${SQL_SERVER:-sql}" -U sa -P "${SA_PASSWORD:-Passw0rd123!}" \
+        -C -No -d CRONUS -b -Q "$1"
+}
+
+cleanup() {
+    sql "
+DELETE FROM [Access Control] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+DELETE FROM [User Property] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+DELETE FROM [User] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+" >/dev/null 2>&1 || true
+    # These files contain response bodies, never request credentials.
+    find "$tmp_dir" -type f -delete 2>/dev/null || true
+    rmdir "$tmp_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+odata_correct=$(status_with_basic_auth "$ODATA_URL" "$BC_SERVER_USERNAME" "$BC_SERVER_PASSWORD" "$tmp_dir/odata-correct")
+odata_wrong=$(status_with_basic_auth "$ODATA_URL" "$BC_SERVER_USERNAME" "$WRONG_PASSWORD" "$tmp_dir/odata-wrong")
+expect_success "OData correct password" "$odata_correct"
+expect_rejected "OData wrong password" "$odata_wrong"
+
+dev_correct=$(status_with_basic_auth "$DEV_URL" "$BC_SERVER_USERNAME" "$BC_SERVER_PASSWORD" "$tmp_dir/dev-correct")
+dev_wrong=$(status_with_basic_auth "$DEV_URL" "$BC_SERVER_USERNAME" "$WRONG_PASSWORD" "$tmp_dir/dev-wrong")
+expect_success "developer endpoint correct password" "$dev_correct"
+expect_rejected "developer endpoint wrong password" "$dev_wrong"
+
+missing=$(status_with_basic_auth "$ODATA_URL" "${BC_SERVER_USERNAME}_AUTH_MISSING" "$BC_SERVER_PASSWORD" "$tmp_dir/missing")
+empty=$(status_with_basic_auth "$ODATA_URL" "$BC_SERVER_USERNAME" "" "$tmp_dir/empty")
+expect_rejected "nonexistent user" "$missing"
+expect_rejected "empty password" "$empty"
+
+if printf '%s' "$BC_SERVER_PASSWORD" | "${COMPOSE[@]}" exec -T bc \
+    env DOTNET_STARTUP_HOOKS= /bc/tools/TestRunner/TestRunner --auth-probe \
+        --host "localhost:7085" --user "$BC_SERVER_USERNAME" \
+        --password-stdin >"$tmp_dir/ws-correct" 2>&1; then
+    echo "PASS  WebSocket correct password"
+else
+    echo "FAIL  WebSocket correct-password probe failed" >&2
+    sed 's/^/  /' "$tmp_dir/ws-correct" >&2
+    exit 1
+fi
+set +e
+printf '%s' "$WRONG_PASSWORD" | "${COMPOSE[@]}" exec -T bc \
+    env DOTNET_STARTUP_HOOKS= /bc/tools/TestRunner/TestRunner --auth-probe \
+        --host "localhost:7085" --user "$BC_SERVER_USERNAME" \
+        --password-stdin >"$tmp_dir/ws-wrong" 2>&1
+ws_wrong_status=$?
+set -e
+case "$ws_wrong_status" in
+    2) echo "PASS  WebSocket wrong password rejected" ;;
+    0) echo "FAIL  WebSocket wrong password authenticated" >&2; exit 1 ;;
+    *)
+        echo "FAIL  WebSocket wrong-password probe failed with non-authentication exit $ws_wrong_status" >&2
+        sed 's/^/  /' "$tmp_dir/ws-wrong" >&2
+        exit 1
+        ;;
+esac
+
+disabled_hash=$(printf '%s' "$BC_SERVER_PASSWORD" | "${COMPOSE[@]}" exec -T bc \
+    env DOTNET_STARTUP_HOOKS= /bc/tools/NavUserPasswordInspector/NavUserPasswordInspector \
+        generate --user-security-id "$DISABLED_GUID")
+expired_hash=$(printf '%s' "$BC_SERVER_PASSWORD" | "${COMPOSE[@]}" exec -T bc \
+    env DOTNET_STARTUP_HOOKS= /bc/tools/NavUserPasswordInspector/NavUserPasswordInspector \
+        generate --user-security-id "$EXPIRED_GUID")
+
+sql "
+DELETE FROM [Access Control] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+DELETE FROM [User Property] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+DELETE FROM [User] WHERE [User Security ID] IN ('$DISABLED_GUID','$EXPIRED_GUID');
+INSERT INTO [User] ([User Security ID],[User Name],[Full Name],[State],[Expiry Date],[Windows Security ID],[Change Password],[License Type],[Authentication Email],[Contact Email],[Exchange Identifier],[Application ID],[\$systemId],[\$systemCreatedAt],[\$systemCreatedBy],[\$systemModifiedAt],[\$systemModifiedBy]) VALUES
+('$DISABLED_GUID',N'$DISABLED_USER_BEFORE',N'Authentication disabled test',0,'2099-12-31',N'',0,0,N'',N'',N'','00000000-0000-0000-0000-000000000000',NEWID(),GETUTCDATE(),'$DISABLED_GUID',GETUTCDATE(),'$DISABLED_GUID'),
+('$EXPIRED_GUID',N'$EXPIRED_USER_BEFORE',N'Authentication expired test',0,'2099-12-31',N'',0,0,N'',N'',N'','00000000-0000-0000-0000-000000000000',NEWID(),GETUTCDATE(),'$EXPIRED_GUID',GETUTCDATE(),'$EXPIRED_GUID');
+INSERT INTO [User Property] ([User Security ID],[Password],[Name Identifier],[Authentication Key],[WebServices Key],[WebServices Key Expiry Date],[Authentication Object ID],[Directory Role ID],[Telemetry User ID],[\$systemId],[\$systemCreatedAt],[\$systemCreatedBy],[\$systemModifiedAt],[\$systemModifiedBy]) VALUES
+('$DISABLED_GUID',N'$disabled_hash',N'',N'',N'','1753-01-01',N'',N'','$DISABLED_GUID',NEWID(),GETUTCDATE(),'$DISABLED_GUID',GETUTCDATE(),'$DISABLED_GUID'),
+('$EXPIRED_GUID',N'$expired_hash',N'',N'',N'','1753-01-01',N'',N'','$EXPIRED_GUID',NEWID(),GETUTCDATE(),'$EXPIRED_GUID',GETUTCDATE(),'$EXPIRED_GUID');
+INSERT INTO [Access Control] ([User Security ID],[Role ID],[Company Name],[Scope],[App ID],[\$systemId],[\$systemCreatedAt],[\$systemCreatedBy],[\$systemModifiedAt],[\$systemModifiedBy]) VALUES
+('$DISABLED_GUID',N'SUPER',N'',0,'00000000-0000-0000-0000-000000000000',NEWID(),GETUTCDATE(),'$DISABLED_GUID',GETUTCDATE(),'$DISABLED_GUID'),
+('$EXPIRED_GUID',N'SUPER',N'',0,'00000000-0000-0000-0000-000000000000',NEWID(),GETUTCDATE(),'$EXPIRED_GUID',GETUTCDATE(),'$EXPIRED_GUID');
+" >/dev/null
+
+disabled_before=$(status_with_basic_auth "$ODATA_URL" "$DISABLED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled-before")
+expired_before=$(status_with_basic_auth "$ODATA_URL" "$EXPIRED_USER_BEFORE" "$BC_SERVER_PASSWORD" "$tmp_dir/expired-before")
+expect_success "disabled test user before disabling" "$disabled_before"
+expect_success "expired test user before expiry" "$expired_before"
+
+sql "
+UPDATE [User]
+SET [User Name] = N'$DISABLED_USER', [State] = 1,
+    [\$systemModifiedAt] = GETUTCDATE(), [\$systemModifiedBy] = '$DISABLED_GUID'
+WHERE [User Security ID] = '$DISABLED_GUID';
+UPDATE [User]
+SET [User Name] = N'$EXPIRED_USER', [Expiry Date] = '2000-01-01',
+    [\$systemModifiedAt] = GETUTCDATE(), [\$systemModifiedBy] = '$EXPIRED_GUID'
+WHERE [User Security ID] = '$EXPIRED_GUID';
+" >/dev/null
+
+disabled=$(status_with_basic_auth "$ODATA_URL" "$DISABLED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/disabled")
+expired=$(status_with_basic_auth "$ODATA_URL" "$EXPIRED_USER" "$BC_SERVER_PASSWORD" "$tmp_dir/expired")
+expect_rejected "disabled user" "$disabled"
+expect_rejected "expired user" "$expired"
+
+echo "Authentication regression: PASS"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -49,6 +49,8 @@ RUN cd src/tools/PatchNclTestPage && dotnet publish -c Release -o /build/output/
 # `docker compose exec` instead of `dotnet run`, removing the host-side
 # .NET 8 SDK requirement for running tests against a Linux BC container.
 RUN cd tools/TestRunner && dotnet publish -c Release -o /build/output/tools/TestRunner 2>&1 | tail -3
+RUN cd tools/NavUserPasswordInspector && dotnet publish -c Release -o /build/output/tools/NavUserPasswordInspector 2>&1 | tail -3
+RUN /build/output/tools/NavUserPasswordInspector/NavUserPasswordInspector self-test
 
 # Native libSkiaSharp.so for BC's report renderer, one per SkiaSharp line
 # Microsoft has shipped (BC 28.x = 3.119.0; 2.88.9 covers the 2.88.x line).

--- a/src/StartupHook/StartupHook.cs
+++ b/src/StartupHook/StartupHook.cs
@@ -357,12 +357,6 @@ internal class StartupHook
             PatchReportingServiceClient(args.LoadedAssembly);
         }
 
-        // Patch #16b: NavUser.TryAuthenticate bypass (password hash doesn't verify on Linux)
-        if (name == "Microsoft.Dynamics.Nav.Ncl")
-        {
-            PatchNavUserTryAuthenticate(args.LoadedAssembly);
-        }
-
         // Patch #22: AzureADGraphQuery constructor bypass.
         //   AL DotNet variable creation of Microsoft.Dynamics.Nav.AzureADGraphClient.GraphQuery
         //   fails on Linux with NavConfigurationException: "LazyEx factory threw an exception".
@@ -495,10 +489,6 @@ internal class StartupHook
         {
             PatchNavFileExpandFileName(args.LoadedAssembly);
         }
-
-        // Patch #16 is now only 16b (NavUser.TryAuthenticate bypass in Nav.Ncl).
-        // The full ValidateAsync chain runs normally to populate the auth cache,
-        // but password hash verification is bypassed via TryAuthenticate.
 
         // Patch #21: NavOpenTaskPageAction.ShowForm crashes on Linux when a test opens a
         // task page — the headless client has no UI renderer and a null reference occurs,
@@ -2566,96 +2556,6 @@ internal class StartupHook
             }
         }
         return null;
-    }
-
-    // ========================================================================
-    // Patch #16: Client Services Credential Bypass
-    // ========================================================================
-
-    private static void PatchClientCredentialValidation(Assembly navServiceAssembly)
-    {
-        try
-        {
-            // Patch the validator to not check the password but still populate the auth cache
-            var validatorType = navServiceAssembly.GetType(
-                "Microsoft.Dynamics.Nav.Service.ClientServicesUserNamePasswordValidator");
-            if (validatorType == null)
-            {
-                Console.WriteLine("[StartupHook] Patch #16: Validator type not found, skipping");
-                return;
-            }
-
-            var validateMethod = validatorType.GetMethod("ValidateAsync",
-                BindingFlags.Instance | BindingFlags.Public);
-            if (validateMethod == null)
-            {
-                Console.WriteLine("[StartupHook] Patch #16: ValidateAsync not found, skipping");
-                return;
-            }
-
-            var replacement = typeof(StartupHook).GetMethod(
-                nameof(Replacement_ValidateCredentials),
-                BindingFlags.Static | BindingFlags.NonPublic);
-            ApplyJmpHook(validateMethod, replacement!, "ClientServicesUserNamePasswordValidator.ValidateAsync");
-            Console.WriteLine("[StartupHook] Patch #16: Client credential validation bypassed");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[StartupHook] Patch #16 failed: {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Replacement for ClientServicesUserNamePasswordValidator.ValidateAsync.
-    /// Always succeeds — credentials are trusted in pipeline/CI scenarios.
-    /// Signature: instance method, ValueTask ValidateAsync(ConnectionCredentials)
-    /// </summary>
-    private static ValueTask Replacement_ValidateCredentials(object? self, object? credentials)
-    {
-        Console.WriteLine("[StartupHook] Credential validation bypassed (Patch #16)");
-        return ValueTask.CompletedTask;
-    }
-
-    /// <summary>
-    /// Patch NavUser.TryAuthenticate to always return true.
-    /// Called from Nav.Ncl.dll when it's loaded.
-    /// The password hash format from Windows doesn't verify correctly on Linux.
-    /// </summary>
-    internal static void PatchNavUserTryAuthenticate(Assembly nclAssembly)
-    {
-        try
-        {
-            var navUserType = nclAssembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavUser");
-            if (navUserType == null) return;
-
-            // There are multiple TryAuthenticate overloads. Patch the one that takes
-            // (NavUser, UserNameSecurityToken, NavTenant) — the NavUserPassword path.
-            foreach (var m in navUserType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
-            {
-                if (m.Name != "TryAuthenticate") continue;
-                var ps = m.GetParameters();
-                if (ps.Length == 3 && ps[1].ParameterType.Name.Contains("UserNameSecurityToken"))
-                {
-                    var replacement = typeof(StartupHook).GetMethod(
-                        nameof(Replacement_TryAuthenticate),
-                        BindingFlags.Static | BindingFlags.NonPublic);
-                    ApplyJmpHook(m, replacement!, "NavUser.TryAuthenticate(NavUser,UserNameSecurityToken,NavTenant)");
-                    Console.WriteLine("[StartupHook] Patch #16b: NavUser.TryAuthenticate bypassed");
-                    return;
-                }
-            }
-            Console.WriteLine("[StartupHook] Patch #16b: TryAuthenticate overload not found");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[StartupHook] Patch #16b failed: {ex.Message}");
-        }
-    }
-
-    private static bool Replacement_TryAuthenticate(object? user, object? token, object? tenant)
-    {
-        Console.WriteLine("[StartupHook] NavUser.TryAuthenticate bypassed — returning true (Patch #16b)");
-        return true;
     }
 
     // ========================================================================

--- a/src/StartupHook/kernel32_stubs.c
+++ b/src/StartupHook/kernel32_stubs.c
@@ -4,6 +4,7 @@
 // dhcpcsvc, Netapi32, ntdsapi, rpcrt4, advapi32.
 
 #include <stdint.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -113,6 +114,11 @@ int GetComputerNameExW(int format, uint16_t* buffer, int* size) {
     int len = 8; // strlen("bcserver")
     if (buffer == 0 || *size < len + 1) {
         *size = len + 1;
+        // DnsHelper calls this once with a null buffer and requires Windows'
+        // ERROR_MORE_DATA before it allocates the StringBuilder. DllImport's
+        // SetLastError reads libc errno on Unix; an exported GetLastError()
+        // function does not populate that captured value.
+        errno = 234;
         return 0; // ERROR_MORE_DATA triggers retry with correct buffer size
     }
     for (int i = 0; i < len; i++) buffer[i] = (uint16_t)name[i];

--- a/tools/NavUserPasswordInspector/NavUserPasswordInspector.csproj
+++ b/tools/NavUserPasswordInspector/NavUserPasswordInspector.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+  </ItemGroup>
+</Project>

--- a/tools/NavUserPasswordInspector/Program.cs
+++ b/tools/NavUserPasswordInspector/Program.cs
@@ -1,0 +1,138 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Security.Cryptography;
+using BcLinux.Authentication;
+using Mono.Cecil;
+
+const string DefaultType = "Microsoft.Dynamics.Nav.Runtime.NavUser";
+const string DefaultMethod = "TryAuthenticate";
+
+try
+{
+    return args.FirstOrDefault() switch
+    {
+        "generate" => Generate(args.Skip(1).ToArray()),
+        "self-test" => SelfTest(),
+        _ => Inspect(args),
+    };
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"NavUserPasswordInspector: {ex.Message}");
+    return 1;
+}
+
+static int Generate(string[] args)
+{
+    var userSecurityIdText = GetOption(args, "--user-security-id")
+        ?? throw new ArgumentException("generate requires --user-security-id <guid>");
+    if (!Guid.TryParse(userSecurityIdText, out var userSecurityId))
+        throw new ArgumentException("--user-security-id is not a valid GUID");
+
+    // The password deliberately travels over stdin, never argv or a temporary file.
+    var password = Console.In.ReadToEnd();
+    if (password.Length == 0)
+        throw new ArgumentException("password on stdin must not be empty");
+
+    Console.Out.Write(V3Password.GenerateStored(password, userSecurityId));
+    return 0;
+}
+
+static int SelfTest()
+{
+    const string expected = "aXD91GRctWiXaqXeWbXhxQ==-V3";
+    var actual = V3Password.GenerateStored(
+        "Admin123!", Guid.Parse("00000000-0000-0000-0000-000000000001"));
+    if (actual != expected)
+        throw new InvalidOperationException("BC V3 historical vector did not match");
+
+    Console.WriteLine("BC V3 historical vector: PASS");
+    return 0;
+}
+
+static int Inspect(string[] args)
+{
+    var serviceDir = GetOption(args, "--service-dir")
+        ?? throw new ArgumentException("inspection requires --service-dir <directory>");
+    var typeName = GetOption(args, "--type") ?? DefaultType;
+    var methodName = GetOption(args, "--method") ?? DefaultMethod;
+    var assemblyPath = GetOption(args, "--assembly")
+        ?? Path.Combine(serviceDir, "Microsoft.Dynamics.Nav.Ncl.dll");
+
+    assemblyPath = Path.GetFullPath(assemblyPath);
+    serviceDir = Path.GetFullPath(serviceDir);
+    if (!File.Exists(assemblyPath))
+        throw new FileNotFoundException("assembly was not found", assemblyPath);
+
+    var resolver = new DefaultAssemblyResolver();
+    resolver.AddSearchDirectory(serviceDir);
+    resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath)!);
+    using var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters
+    {
+        AssemblyResolver = resolver,
+        ReadSymbols = false,
+        ReadingMode = ReadingMode.Deferred,
+        InMemory = true,
+    });
+
+    var file = FileVersionInfo.GetVersionInfo(assemblyPath);
+    var targetFramework = assembly.CustomAttributes
+        .FirstOrDefault(a => a.AttributeType.FullName == typeof(System.Runtime.Versioning.TargetFrameworkAttribute).FullName)
+        ?.ConstructorArguments.FirstOrDefault().Value?.ToString() ?? "<none>";
+
+    Console.WriteLine($"Path: {assemblyPath}");
+    Console.WriteLine($"SHA256: {Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(assemblyPath))).ToLowerInvariant()}");
+    Console.WriteLine($"Assembly: {assembly.Name.FullName}");
+    Console.WriteLine($"FileVersion: {file.FileVersion ?? "<none>"}");
+    Console.WriteLine($"TargetFramework: {targetFramework}");
+    Console.WriteLine($"MVID: {assembly.MainModule.Mvid:D}");
+
+    var type = assembly.MainModule.GetType(typeName)
+        ?? assembly.MainModule.Types.SelectMany(Flatten).FirstOrDefault(t => t.FullName == typeName)
+        ?? throw new InvalidOperationException($"type not found: {typeName}");
+    var methods = type.Methods.Where(m => m.Name == methodName).ToArray();
+    if (methods.Length == 0)
+        throw new InvalidOperationException($"method not found: {typeName}.{methodName}");
+
+    foreach (var method in methods)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Method: {method.FullName}");
+        Console.WriteLine($"MetadataToken: {method.MetadataToken}");
+        if (!method.HasBody)
+        {
+            Console.WriteLine("  <no method body>");
+            continue;
+        }
+
+        foreach (var instruction in method.Body.Instructions)
+        {
+            var operand = instruction.Operand switch
+            {
+                MethodReference called => called.FullName,
+                FieldReference field => field.FullName,
+                TypeReference referencedType => referencedType.FullName,
+                null => "",
+                _ => instruction.Operand.ToString() ?? "",
+            };
+            Console.WriteLine($"  IL_{instruction.Offset:x4}: {instruction.OpCode.Name,-12} {operand}");
+        }
+    }
+
+    return 0;
+}
+
+static IEnumerable<TypeDefinition> Flatten(TypeDefinition type)
+{
+    yield return type;
+    foreach (var nested in type.NestedTypes.SelectMany(Flatten))
+        yield return nested;
+}
+
+static string? GetOption(string[] args, string name)
+{
+    for (var i = 0; i < args.Length; i++)
+        if (args[i] == name && i + 1 < args.Length)
+            return args[i + 1];
+    return null;
+}

--- a/tools/NavUserPasswordInspector/V3Password.cs
+++ b/tools/NavUserPasswordInspector/V3Password.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BcLinux.Authentication;
+
+public static class V3Password
+{
+    // Decompiled from Microsoft.Dynamics.Nav.Core.CryptographyHelper:
+    // GeneratePasswordHash uses Guid.Empty; GenerateSaltedPasswordHash then
+    // applies the user's security ID and the production iteration count.
+    public static string GenerateInner(string password)
+    {
+        var bytes = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password),
+            Guid.Empty.ToByteArray(),
+            iterations: 1,
+            HashAlgorithmName.SHA256,
+            outputLength: 16);
+        return Convert.ToBase64String(bytes) + "-V3";
+    }
+
+    public static string GenerateStored(string password, Guid userSecurityId)
+    {
+        var inner = GenerateInner(password);
+        var bytes = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(inner),
+            userSecurityId.ToByteArray(),
+            iterations: 100_000,
+            HashAlgorithmName.SHA256,
+            outputLength: 16);
+        return Convert.ToBase64String(bytes) + "-V3";
+    }
+}

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -7,6 +7,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BcLinux.Authentication;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StreamJsonRpc;
@@ -38,6 +39,8 @@ var maxIterations = 500;
 var numCodeunitsOverride = 0; // explicit codeunit count for progress display
 var verbose = false;
 var junitOutput = ""; // path to write JUnit XML — empty = don't emit
+var authProbe = false; // authenticate through OpenConnection only; never open a company or run AL tests
+const int AuthenticationRejectedExitCode = 2;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -46,6 +49,7 @@ for (int i = 0; i < args.Length; i++)
     else if (args[i] == "--company" && i + 1 < args.Length) company = args[++i];
     else if (args[i] == "--user" && i + 1 < args.Length) user = args[++i];
     else if (args[i] == "--password" && i + 1 < args.Length) password = args[++i];
+    else if (args[i] == "--password-stdin") password = Console.In.ReadToEnd();
     else if (args[i] == "--timeout" && i + 1 < args.Length) timeoutMin = int.Parse(args[++i]);
     else if (args[i] == "--codeunit-timeout" && i + 1 < args.Length) codeunitTimeoutMin = int.Parse(args[++i]);
     else if (args[i] == "--suite" && i + 1 < args.Length) suiteName = args[++i];
@@ -54,6 +58,7 @@ for (int i = 0; i < args.Length; i++)
     else if (args[i] == "--num-codeunits" && i + 1 < args.Length) numCodeunitsOverride = int.Parse(args[++i]);
     else if (args[i] == "--verbose" || args[i] == "-v") verbose = true;
     else if (args[i] == "--junit-output" && i + 1 < args.Length) junitOutput = args[++i];
+    else if (args[i] == "--auth-probe") authProbe = true;
     else if (!args[i].StartsWith("--")) host = args[i];
 }
 
@@ -74,9 +79,35 @@ var recordedResults = new List<RecordedResult>();
 void Log(string msg) { if (verbose) Console.Error.WriteLine(msg); }
 
 int exitCode = 1;
-try { exitCode = await RunTests(); }
+try { exitCode = authProbe ? await RunAuthenticationProbe() : await RunTests(); }
 catch (Exception ex) { Console.Error.WriteLine($"FATAL: {ex.Message}"); }
 return exitCode;
+
+async Task<int> RunAuthenticationProbe()
+{
+    var authBytes = Encoding.UTF8.GetBytes($"{user}:{password}");
+    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+    var tokenCapture = new MetadataTokenCapture();
+    try
+    {
+        var (rpc, ws, sessionEndedCts) = await Connect(authBytes, tokenCapture, cts.Token);
+        using (sessionEndedCts)
+        using (rpc)
+        using (ws)
+        {
+            // OpenConnection in Connect is the authentication boundary. Do not
+            // open a country-specific company here: that would turn a valid
+            // login into a false authentication failure on non-W1 artifacts.
+            Console.WriteLine("WebSocket/client-services authentication: PASS");
+            return 0;
+        }
+    }
+    catch (RemoteInvocationException ex) when (IsAuthenticationRejection(ex))
+    {
+        Console.Error.WriteLine($"AUTH_REJECTED: {ex.Message}");
+        return AuthenticationRejectedExitCode;
+    }
+}
 
 async Task<int> RunTests()
 {
@@ -411,23 +442,55 @@ async Task<JToken?> Invoke(JsonRpc rpc, JToken? formState, string action, Cancel
 
 async Task<(JsonRpc, ClientWebSocket, CancellationTokenSource)> Connect(byte[] authBytes, MetadataTokenCapture tc, CancellationToken ct)
 {
+    var currentPassword = V3Password.GenerateInner(password);
+    try
+    {
+        return await ConnectOnce(authBytes, currentPassword, tc, ct);
+    }
+    catch (RemoteInvocationException ex) when (IsAuthenticationRejection(ex))
+    {
+        // BC 26 requires a second, legacy-password slot. Later versions accept
+        // the current V3 value directly. Negotiate from server behavior instead
+        // of relying on BC_VERSION, which is absent in host-side runner paths.
+        Log("Current V3 credential was rejected; retrying with the BC 26 legacy slot.");
+        return await ConnectOnce(authBytes, currentPassword + "|", tc, ct);
+    }
+}
+
+async Task<(JsonRpc, ClientWebSocket, CancellationTokenSource)> ConnectOnce(
+    byte[] authBytes, string clientServicesPassword, MetadataTokenCapture tc, CancellationToken ct)
+{
     Log($"Connecting to ws://{host}/ws/connect");
     var sessionEndedCts = new CancellationTokenSource();
     var ws = new ClientWebSocket();
-    ws.Options.SetRequestHeader("Authorization", $"Basic {Convert.ToBase64String(authBytes)}");
-    await ws.ConnectAsync(new Uri($"ws://{host}/ws/connect"), ct);
-    var rpc = new JsonRpc(new WebSocketMessageHandler(ws));
-    rpc.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.Verbose;
-    rpc.TraceSource.Listeners.Add(tc);
-    var callbacks = new Callbacks(sessionEndedCts);
-    rpc.AddLocalRpcTarget(callbacks);
-    callbacks.Rpc = rpc;
-    rpc.StartListening();
-    await rpc.InvokeWithCancellationAsync<JToken>("OpenConnection",
-        new object[] { new { LCID = 1033, DefaultLCID = 1033, TimeZoneId = "UTC", Credentials = new { UserName = user, Password = password } } }, ct);
-    Log("Connected.");
-    return (rpc, ws, sessionEndedCts);
+    JsonRpc? rpc = null;
+    try
+    {
+        ws.Options.SetRequestHeader("Authorization", $"Basic {Convert.ToBase64String(authBytes)}");
+        await ws.ConnectAsync(new Uri($"ws://{host}/ws/connect"), ct);
+        rpc = new JsonRpc(new WebSocketMessageHandler(ws));
+        rpc.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.Verbose;
+        rpc.TraceSource.Listeners.Add(tc);
+        var callbacks = new Callbacks(sessionEndedCts);
+        rpc.AddLocalRpcTarget(callbacks);
+        callbacks.Rpc = rpc;
+        rpc.StartListening();
+        await rpc.InvokeWithCancellationAsync<JToken>("OpenConnection",
+            new object[] { new { LCID = 1033, DefaultLCID = 1033, TimeZoneId = "UTC", Credentials = new { UserName = user, Password = clientServicesPassword } } }, ct);
+        Log("Connected.");
+        return (rpc, ws, sessionEndedCts);
+    }
+    catch
+    {
+        rpc?.Dispose();
+        ws.Dispose();
+        sessionEndedCts.Dispose();
+        throw;
+    }
 }
+
+static bool IsAuthenticationRejection(Exception ex) =>
+    ex.Message.Contains("rejected the client credentials", StringComparison.OrdinalIgnoreCase);
 
 async Task<JToken?> OpenTestPage(JsonRpc rpc, MetadataTokenCapture tc, string company, CancellationToken ct)
 {

--- a/tools/TestRunner/TestRunner.csproj
+++ b/tools/TestRunner/TestRunner.csproj
@@ -6,6 +6,7 @@
     <NoWarn>VSTHRD103;VSTHRD105;VSTHRD200;CS0219</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="../NavUserPasswordInspector/V3Password.cs" Link="V3Password.cs" />
     <PackageReference Include="StreamJsonRpc" Version="2.19.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>


### PR DESCRIPTION
This change fixes a security problem in the Linux startup hooks.

The old code made every existing user authenticate successfully, regardless of the password. The startup hook now leaves Business Central’s normal password verification in place and creates the same password format that Business Central expects from the configured server password. Wrong passwords, missing users, disabled users, and expired users are rejected.

The change was tested with Business Central 28.4, 27.5, and 26.5 on Linux against OData, the developer endpoint, and client services over WebSocket. Correct passwords succeeded and deliberately wrong passwords were rejected. The BC 28 web client was also tested: correct credentials reached the client and wrong credentials remained at the sign-in page.

The client-services password envelope differs by platform version: BC 26 requires the current V3 value followed by an empty legacy slot (V3|), while BC 27 and BC 28 use the single V3 value. The code now applies the V3| form only to BC 26.

The investigation also found and fixed a separate BC 26 startup issue in the Unix hostname compatibility stub.

The SQL connection encryption and tenant encryption patches were not changed.
