### PR TITLE
Fixed path separators for OnPrem artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -812,11 +812,11 @@ The fix is **additive, not a migration**: the image installs both shared
 frameworks side by side and picks per BC version at boot. Nothing about the
 .NET 8 path changed.
 
-- **`src/Dockerfile`** — the builder stays on the bookworm-based `sdk:8.0`
+- **`src/Dockerfile`** — the builder stays on the noble-based `sdk:8.0-noble-amd64`
   and adds the .NET 10 SDK via `dotnet-install.sh`. Do **not** switch the
   base to `sdk:10.0`: that image is trixie, and `libwin32_stubs.so` is
-  compiled here with gcc and has to keep running against the bookworm glibc
-  in the `aspnet:8.0` runtime stage. The runtime stage adds the .NET 10
+  compiled here with gcc and has to keep running against the noble glibc
+  in the `aspnet:8.0-noble-amd64` runtime stage. The runtime stage adds the .NET 10
   ASP.NET Core runtime the same way (which brings `Microsoft.NETCore.App`
   10 with it). A net8.0 app does **not** roll forward to 10 while 8 is
   installed, so BC 27/28 keep resolving 8.0.

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -220,10 +220,12 @@ files = [i for i in infos if not i.is_dir()]
 
 # Pre-create every directory up front: zipfile's internal makedirs is not
 # race-safe, and the workers below extract concurrently.
-for i in files:
-    safe_filename = i.filename.replace('\\', '/').lstrip('/')
-    
-    d = os.path.dirname(safe_filename)
+dirs = {
+    os.path.dirname(i.filename.replace('\\', '/').lstrip('/'))
+    for i in files
+}
+
+for d in dirs:
     if d:
         os.makedirs(os.path.join(dest, d), exist_ok=True)
 

--- a/scripts/download-artifacts.sh
+++ b/scripts/download-artifacts.sh
@@ -210,6 +210,8 @@ _extract_zip() {
 import os, sys, zipfile
 from concurrent.futures import ThreadPoolExecutor
 
+os.path.altsep = '\\'
+
 zip_path, dest = sys.argv[1], sys.argv[2]
 
 with zipfile.ZipFile(zip_path) as zf:
@@ -218,7 +220,10 @@ files = [i for i in infos if not i.is_dir()]
 
 # Pre-create every directory up front: zipfile's internal makedirs is not
 # race-safe, and the workers below extract concurrently.
-for d in {os.path.dirname(i.filename) for i in files}:
+for i in files:
+    safe_filename = i.filename.replace('\\', '/').lstrip('/')
+    
+    d = os.path.dirname(safe_filename)
     if d:
         os.makedirs(os.path.join(dest, d), exist_ok=True)
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -174,8 +174,8 @@ log_step "Disk: $(df -h /bc/artifacts | tail -1 | awk '{print $4 " free"}')"
 log_step "Reading manifest..."
 MANIFEST="$ARTIFACTS/app/manifest.json"
 ls -la "$MANIFEST" || { log_step "FATAL: manifest.json not found at $MANIFEST"; exit 1; }
-DB_FILE=$(python3 -c "import json; print(json.load(open('$MANIFEST')).get('database',''))")
-LICENSE_FILE=$(python3 -c "import json; print(json.load(open('$MANIFEST')).get('licenseFile',''))")
+DB_FILE=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("database", "").replace("\\", "/"))' "$MANIFEST")
+LICENSE_FILE=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("licenseFile", "").replace("\\", "/"))' "$MANIFEST")
 PLATFORM_VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['platform'])")
 MAJOR_VERSION=$(echo "$PLATFORM_VERSION" | cut -d. -f1)
 NAV_DIR="${MAJOR_VERSION}0"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: compile StartupHook + stubs + tools
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:8.0-noble-amd64 AS builder
 
 # gcc needed for compiling Win32 P/Invoke stubs (kernel32_stubs.c → libwin32_stubs.so);
 # unzip for extracting libSkiaSharp.so out of NuGet packages (nupkg = zip)
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev u
 # .NET 10 SDK alongside the 8.0 SDK this image ships. BC 27/28 target net8.0,
 # BC 29 targets net10.0, and the framework-impersonating stubs + Cecil reference
 # assemblies have to be produced for BOTH. Deliberately installed on top of the
-# bookworm-based sdk:8.0 image rather than switching the base to sdk:10.0
-# (trixie): libwin32_stubs.so is compiled here with gcc and has to keep running
-# against the bookworm glibc in the aspnet:8.0 runtime stage.
+# noble-based sdk:8.0 image rather than switching the base to sdk:10.0
+# libwin32_stubs.so is compiled here with gcc and has to keep running
+# against the noble glibc in the aspnet:8.0 runtime stage.
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
     bash /tmp/dotnet-install.sh --channel 10.0 --install-dir /usr/share/dotnet && \
     rm /tmp/dotnet-install.sh && \
@@ -106,7 +106,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libharfbuzz0b libfreetype6 fontconfig fonts-liberation && \
     sed -i '/en_US.UTF-8/s/^# //' /etc/locale.gen && locale-gen && \
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/mssql.list && \
+    echo "deb [signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/24.04/prod noble main" > /etc/apt/sources.list.d/mssql.list && \
     ACCEPT_EULA=Y apt-get update && ACCEPT_EULA=Y apt-get install -y --no-install-recommends mssql-tools18 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -89,7 +89,7 @@ RUN mkdir -p /build/output/refasm /build/output/refasm-net10 && \
     echo "Copied $(ls /build/output/refasm/*.dll | wc -l) net8.0 + $(ls /build/output/refasm-net10/*.dll | wc -l) net10.0 reference assemblies"
 
 # Runtime stage: minimal image
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:8.0
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:8.0-noble-amd64
 
 # Install tools for artifact download and SQL setup + en_US locale.
 # harfbuzz/freetype/fontconfig/fonts: BC's report renderer text-shapes via native


### PR DESCRIPTION
Fixes #42 

What was changed:

1. Switching the ASP.NET image in `download-artifacts.sh`  to `mcr.microsoft.com/dotnet/aspnet:8.0-noble-amd64`. This one has python 3.12, which fixes bug mentioned python/cpython/issues/117084
2. Add `os.path.altsep = '\\'` to the beginning of artifact extraction
3. Fix folder pre-creation in `download-artifacts.sh` to generate clean paths
4. Fix `DB_FILE` and `LICENSE_FILE` paths in `entrypoint.sh`