### PR TITLE
fix: ISV extension installs fail with misleading SUPER-user error (two independent bugs)

### DIFF
--- a/KNOWN-LIMITATIONS.md
+++ b/KNOWN-LIMITATIONS.md
@@ -192,3 +192,53 @@ pass-through fake structurally cannot satisfy:
 blob content hash, etc.) pass. Real encryption semantics (actual AES/RSA,
 genuine key provisioning, toggle support) would need Patch #7's original
 "real work" scope — flagged as infra work, not attempted here.
+
+## ~~ISV extension installs fail with "You must assign at least one user the SUPER permission set..."~~ (FIXED — entrypoint.sh + Patch #22b)
+
+**Symptom**: publishing/installing a third-party extension whose install
+codeunit performs any transaction-committing operation (e.g. Continia
+OPplus's install codeunit, which calls Microsoft's `IsPlanAssignedToUser`)
+fails on BC Linux with:
+
+```
+You must assign at least one user the SUPER permission set and configure
+that user to log in with authentication type 'NavUserPassword', which is
+supported by the current server instance.
+```
+
+...even when a NavUserPassword SUPER user obviously exists and is
+reachable via OData/dev-endpoint with the same credentials. This message
+is BC's own generic fallback for ANY failed install-transaction commit,
+not specifically about a missing/misconfigured SUPER user — so it hid
+**two independent, unrelated bugs** that both happened to surface through
+it. Neither showed a real exception in BC's normal logs: install-time
+exceptions are reported via `NavCSideException` with the message text
+redacted ("Message not shown because the NavBaseException constructor
+was used without privacy classification"); both needed
+`BC_DEBUG_FIRSTCHANCE=1` plus decompiling `Microsoft.Dynamics.Nav.Ncl.dll`
+to actually find.
+
+**Bug 1 (entrypoint.sh)**: the bootstrap `BC_SERVER_USERNAME` and
+`YOURBC-SERVICEUSER` accounts had `[User].[Expiry Date]` set to
+`2099-12-31`, on the assumption that "a date far enough in the future"
+means "never expires". BC's own
+`SystemTableTriggers.CheckForExistenceOfSuperUserIfNecessaryAsync` query
+(decompiled from `Nav.Ncl.dll`) filters candidate SUPER users to
+`expiryDateField.Equal(NavDateTime.Undefined)` — the platform's actual
+"never expires" sentinel, `1753-01-01` — so both bootstrap users were
+silently excluded from every SUPER-user check. Fixed by using
+`1753-01-01` for both, matching the convention BC itself already used two
+lines below for `[User Property].[WebServices Key Expiry Date]`.
+
+**Bug 2 (StartupHook.cs, Patch #22b)**: even with Bug 1 fixed, AL's
+`GraphQuery` DotNet variable's `GetTenantDetail()` call (reached via
+`IsPlanAssignedToUser`) threw a `NullReferenceException` on a null
+`currentSession`, unrelated to SUPER/user config at all — see the
+Patch #22b header comment in `StartupHook.cs` for the full root cause
+(GraphQuery's own ctor always passes a null session to its inner
+`AzureADGraphQuery`, regardless of what's actually current).
+
+**Verified live end-to-end** with both fixes applied: Continia OPplus
+(and its dependencies — Continia System Application, Continia Core,
+Continia Connector App — plus its own Trial Balance VAT DACH add-on)
+all install successfully against a freshly created container.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -860,6 +860,20 @@ fi
 # an "ADMIN" user; override via BC_SERVER_USERNAME/BC_SERVER_PASSWORD (docker-compose.yml
 # passes these through — see the comment there). GUID 00000000-0000-0000-0000-000000000001.
 #
+# [User].[Expiry Date] MUST be '1753-01-01' (BC's "never expires" sentinel/NavDateTime.Undefined),
+# NOT a real future date like '2099-12-31' -- confirmed by decompiling
+# SystemTableTriggers.CheckForExistenceOfSuperUserIfNecessaryAsync (Nav.Ncl.dll): its
+# GenerateSuperUserAuthenticationMethodQuery join filters candidate SUPER users to
+# expiryDateField.Equal(NavDateTime.Undefined), so a real Expiry Date -- even one far in the
+# future and clearly intended to mean "does not expire" -- silently excludes the user from
+# that query, making CheckSuperUserAuthenticationMethodQueryAsync see zero qualifying rows and
+# throw "You must assign at least one user the SUPER permission set...". This fires on ANY
+# operation that commits a transaction while requiring a live SUPER user check -- reproduced
+# via extension installs (e.g. publishing Continia OPplus), not something specific to that app.
+# 2099-12-31 was previously used here on the mistaken assumption that BC just wants "a date far
+# enough in the future"; the platform's own convention (see [User Property].[WebServices Key
+# Expiry Date] two lines below, which already correctly used 1753-01-01) says otherwise.
+#
 # The stored password hash is a fixed placeholder, NOT a hash of BC_SERVER_PASSWORD —
 # NavUser.TryAuthenticate's hash check doesn't verify on Linux (the Windows hash format
 # doesn't port; StartupHook Patch #16b bypasses verification and always returns true),
@@ -880,7 +894,7 @@ BEGIN
         [Windows Security ID], [Change Password], [License Type], [Authentication Email],
         [Contact Email], [Exchange Identifier], [Application ID],
         [\$systemId], [\$systemCreatedAt], [\$systemCreatedBy], [\$systemModifiedAt], [\$systemModifiedBy])
-    VALUES ('$USER_GUID', N'$BC_SERVER_USERNAME', N'BC Runner', 0, '2099-12-31', N'S-1-5-21-2074085148-119339936-2019613796-1001', 0, 0, N'', N'', N'',
+    VALUES ('$USER_GUID', N'$BC_SERVER_USERNAME', N'BC Runner', 0, '1753-01-01', N'S-1-5-21-2074085148-119339936-2019613796-1001', 0, 0, N'', N'', N'',
         '00000000-0000-0000-0000-000000000000',
         NEWID(), GETUTCDATE(), '$USER_GUID', GETUTCDATE(), '$USER_GUID');
     INSERT INTO [User Property] ([User Security ID], [Password], [Name Identifier],
@@ -908,7 +922,7 @@ BEGIN
         [Windows Security ID], [Change Password], [License Type], [Authentication Email],
         [Contact Email], [Exchange Identifier], [Application ID],
         [\$systemId], [\$systemCreatedAt], [\$systemCreatedBy], [\$systemModifiedAt], [\$systemModifiedBy])
-    VALUES ('$SVC_GUID', N'YOURBC-SERVICEUSER', N'BC Service', 0, '2099-12-31', N'S-1-5-21-572246948-1269080603-559786204-1001', 0, 0, N'', N'', N'',
+    VALUES ('$SVC_GUID', N'YOURBC-SERVICEUSER', N'BC Service', 0, '1753-01-01', N'S-1-5-21-572246948-1269080603-559786204-1001', 0, 0, N'', N'', N'',
         '00000000-0000-0000-0000-000000000000',
         NEWID(), GETUTCDATE(), '$SVC_GUID', GETUTCDATE(), '$SVC_GUID');
     INSERT INTO [User Property] ([User Security ID], [Password], [Name Identifier],

--- a/src/StartupHook/StartupHook.cs
+++ b/src/StartupHook/StartupHook.cs
@@ -51,6 +51,20 @@ using System.Threading.Tasks;
 ///   session on Linux. Fix: no-op the ctor — fields stay default; tests don't need real
 ///   Azure AD calls, only that the GraphQuery DotNet object can be constructed.
 ///
+/// Patch #22b: GraphQuery.GetTenantDetail (Microsoft.Dynamics.Nav.AzureADGraphClient.dll,
+///   Add-ins/GraphClient/ — a separate, lazily-loaded assembly from Nav.Ncl.dll)
+///   Even with Patch #22 applied, calling GraphQuery.GetTenantDetail() (reached from AL's
+///   IsPlanAssignedToUser, used by several ISV install codeunits e.g. Continia OPplus) still
+///   throws NullReferenceException: GraphQuery's own parameterless ctor always builds its
+///   inner AzureADGraphQuery with a null NavSession regardless of what session is actually
+///   current, and GetTenantDetailAsync unconditionally dereferences that null session before
+///   reaching its own "no AAD tenant, use an empty TenantInfo" fallback. BC reports the NRE via
+///   a generic, misleading "You must assign at least one user the SUPER permission set..."
+///   error — the fallback message for ANY failed install-transaction commit, not actually
+///   about SUPER/NavUserPassword. Fix: hook the synchronous GetTenantDetail() wrapper (NOT the
+///   async GetTenantDetailAsync — see Patch #20's own comment on why hooking an async method
+///   mid-flight risks AccessViolationException) to return an empty TenantInfo directly.
+///
 /// Patch #23: OfficeWordDocumentPictureMerger.ReplaceMissingImageWithTransparentImage
 ///   (Microsoft.Dynamics.Nav.OpenXml.dll)
 ///   Microsoft's Word report image merger has a recursion bug: when a Word document
@@ -373,6 +387,15 @@ internal class StartupHook
         if (name == "Microsoft.Dynamics.Nav.Ncl")
         {
             PatchAzureADGraphQuery(args.LoadedAssembly);
+        }
+
+        // Patch #22b: GraphQuery.GetTenantDetail — see PatchGraphQueryGetTenantDetail's header
+        // comment for the full story. Microsoft.Dynamics.Nav.AzureADGraphClient.dll (Add-ins/
+        // GraphClient/) is a SEPARATE, lazily-loaded assembly from Nav.Ncl.dll, so it needs its
+        // own AssemblyLoad hook rather than piggybacking on Patch #22's Nav.Ncl-triggered one.
+        if (name == "Microsoft.Dynamics.Nav.AzureADGraphClient")
+        {
+            ApplyGraphQueryGetTenantDetailPatch(args.LoadedAssembly);
         }
 
         // Patch #26: TenantEncryptionProviderFactory.GetTenantEncryptionProvider bypass.
@@ -2721,6 +2744,11 @@ internal class StartupHook
     // Patch #22: AzureADGraphQuery constructor bypass
     // ========================================================================
 
+    // AzureADGraphQuery.currentSession (private readonly field) — set via reflection
+    // by the replacement ctor below so post-construction calls that don't go through
+    // GetTenantDetail (see below) don't NRE on it either.
+    private static FieldInfo? _aadgqCurrentSessionField;
+
     private static void PatchAzureADGraphQuery(Assembly navNcl)
     {
         try
@@ -2750,6 +2778,19 @@ internal class StartupHook
                 return;
             }
 
+            _aadgqCurrentSessionField = queryType.GetField("currentSession",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (_aadgqCurrentSessionField == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #22: AzureADGraphQuery.currentSession field not found — skipping ctor fix (GetTenantDetail fix below is independent)");
+            }
+
+            // NavCurrentThread.Session accessor is shared with Patch #27/#28; resolve if
+            // neither ran first (load order between patches is not guaranteed).
+            _navCurrentThreadSessionProp ??= navNcl
+                .GetType("Microsoft.Dynamics.Nav.Runtime.NavCurrentThread")
+                ?.GetProperty("Session", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
             var replacement = typeof(StartupHook).GetMethod(
                 nameof(Replacement_AzureADGraphQueryCtor),
                 BindingFlags.Static | BindingFlags.NonPublic)!;
@@ -2760,20 +2801,178 @@ internal class StartupHook
         {
             Console.WriteLine($"[StartupHook] Patch #22 failed: {ex.GetType().Name}: {ex.Message}");
         }
+
+        PatchGraphQueryGetTenantDetail(navNcl);
     }
 
     /// <summary>
     /// No-op replacement for AzureADGraphQuery..ctor(NavSession session).
     /// Skips LazyEx factory setup that requires Azure.Identity / MSAL Windows credential APIs.
-    /// The object is heap-allocated before this ctor runs, so all fields remain default (null/0).
-    /// Tests that reach this path don't need real Azure AD calls — they just need the
-    /// GraphQuery DotNet object to be created without crashing the session.
+    /// The object is heap-allocated before this ctor runs, so all fields remain default (null/0)
+    /// EXCEPT currentSession, which this replacement sets explicitly via reflection so any
+    /// OTHER GraphQuery method than GetTenantDetail (see PatchGraphQueryGetTenantDetail below)
+    /// doesn't immediately NRE on a null currentSession.Diagnostics dereference.
+    ///
+    /// This alone is NOT sufficient to fix GetTenantDetail: the actual runtime call path for
+    /// AL's "GraphQuery" DotNet variable is Microsoft.Dynamics.Nav.AzureADGraphClient.GraphQuery
+    /// (a separate wrapper class in Add-ins/GraphClient/*.dll, not this AzureADGraphQuery),
+    /// whose own parameterless constructor ALWAYS builds
+    /// `azureADGraphQuery = new AzureADGraphQuery((NavSession)null)` regardless of what session
+    /// is actually current — so the session this ctor patch resolves is immediately discarded by
+    /// that caller anyway. See PatchGraphQueryGetTenantDetail for the fix that actually matters.
+    ///
+    /// Session is resolved the same way Patch #27 already resolves it (NavCurrentThread.Session).
     /// Signature: instance ctor → JMP hook passes (this, NavSession) as (object, object).
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Replacement_AzureADGraphQueryCtor(object self, object? session)
     {
+        try
+        {
+            var resolvedSession = session ?? _navCurrentThreadSessionProp?.GetValue(null);
+            _aadgqCurrentSessionField?.SetValue(self, resolvedSession);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #22: failed to set currentSession: {ex.GetType().Name}: {ex.Message}");
+        }
         Console.WriteLine("[StartupHook] Patch #22: AzureADGraphQuery..ctor skipped (no Azure AD on Linux)");
+    }
+
+    // ========================================================================
+    // Patch #22b: GraphQuery.GetTenantDetail — return an empty TenantInfo directly.
+    //
+    // The AL DotNet variable "GraphQuery" (Microsoft.Dynamics.Nav.AzureADGraphClient.GraphQuery,
+    // NOT the AzureADGraphQuery patched above) always constructs its inner AzureADGraphQuery
+    // with a null NavSession (decompiled: `azureADGraphQuery = new AzureADGraphQuery((NavSession)null)`
+    // in GraphQuery's own parameterless ctor) — so Patch #22's ctor fix, which sets currentSession
+    // on THAT inner object, never even runs for this call path (the ctor overload it hooks takes
+    // an explicit NavSession argument; the null-literal call site is a different overload/path).
+    //
+    // GetTenantDetailAsync (the method actually reached) unconditionally dereferences
+    // currentSession.Diagnostics at its very first line for a timing scope, before any of its own
+    // "no AAD tenant configured, use an empty TenantInfo" fallback logic runs. With currentSession
+    // null, that first dereference throws a NullReferenceException. BC's extension-install pipeline
+    // then reports this as the generic, misleading "You must assign at least one user the SUPER
+    // permission set and configure that user to log in with authentication type 'NavUserPassword'"
+    // error — that message is BC's fallback for ANY failed install-transaction commit, not actually
+    // about SUPER/NavUserPassword. Reproduced live: Continia OPplus's own install codeunit calls
+    // Microsoft's IsPlanAssignedToUser, which reaches exactly this NRE via
+    // GraphQuery.GetTenantDetail → AzureADGraphQuery.GetTenantDetailAsync.
+    //
+    // Fix: hook GraphQuery.GetTenantDetail() itself — NOT GetTenantDetailAsync, which is `async`
+    // and reached from a compiler-generated state machine; JMP-hooking an async method mid-flight
+    // is exactly the "AccessViolationException" hazard Patch #20's own comment on EnsureAlive
+    // warns about. GetTenantDetail() is the plain synchronous public wrapper
+    // (`return GetTenantDetailAsync().AsTask().GetAwaiter().GetResult();`) that AL's DotNet
+    // variable calls into, so hooking it is as safe as the ordinary instance-method hooks used
+    // throughout this file. Tests/installs that reach this path don't need a real Azure AD
+    // tenant — they only need SOME non-throwing TenantInfo, which is what Microsoft's own
+    // fallback (AzureADGraphQuery.CreateEmptyTenantInfo, confirmed via decompilation) already
+    // returns for a tenant with no AAD tenant id configured. This patch produces the equivalent
+    // object directly, without depending on that internal fallback ever being reached.
+    // ========================================================================
+
+    private static Type? _tenantInfoType;
+
+    private static void PatchGraphQueryGetTenantDetail(Assembly navNcl)
+    {
+        if (IsPatchDisabled("22b")) return;
+        try
+        {
+            // GraphQuery lives in Add-ins/GraphClient/Microsoft.Dynamics.Nav.AzureADGraphClient.dll,
+            // a SEPARATE assembly from Nav.Ncl.dll (the navNcl parameter here) — it is loaded lazily,
+            // on first AL DotNet variable creation of "GraphQuery", not at NST startup. Resolve it via
+            // AppDomain.CurrentDomain.GetAssemblies() at patch time (called from the same
+            // AssemblyLoad callback as Patch #22, so may run before or after that assembly is loaded);
+            // if not yet loaded, register interest and patch it when it does load instead.
+            var graphClientAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.AzureADGraphClient");
+
+            if (graphClientAssembly == null)
+            {
+                // Not loaded yet — the AssemblyLoad handler in Initialize() re-invokes this same
+                // patch by name once it does load (see the dedicated hook registered there).
+                Console.WriteLine("[StartupHook] Patch #22b: Microsoft.Dynamics.Nav.AzureADGraphClient not yet loaded — will retry when it loads");
+                return;
+            }
+
+            ApplyGraphQueryGetTenantDetailPatch(graphClientAssembly);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #22b failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static bool _graphQueryPatchApplied;
+
+    private static void ApplyGraphQueryGetTenantDetailPatch(Assembly graphClientAssembly)
+    {
+        if (_graphQueryPatchApplied) return;
+        try
+        {
+            var graphQueryType = graphClientAssembly.GetType("Microsoft.Dynamics.Nav.AzureADGraphClient.GraphQuery");
+            if (graphQueryType == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #22b: GraphQuery type not found — skipping");
+                return;
+            }
+
+            var getTenantDetail = graphQueryType.GetMethod("GetTenantDetail",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null, types: Type.EmptyTypes, modifiers: null);
+            if (getTenantDetail == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #22b: GraphQuery.GetTenantDetail() not found — skipping");
+                return;
+            }
+
+            _tenantInfoType = getTenantDetail.ReturnType;
+
+            var replacement = typeof(StartupHook).GetMethod(
+                nameof(Replacement_GraphQueryGetTenantDetail),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            ApplyJmpHook(getTenantDetail, replacement, "GraphQuery.GetTenantDetail");
+            _graphQueryPatchApplied = true;
+            Console.WriteLine("[StartupHook] Patch #22b: GraphQuery.GetTenantDetail hooked — returns an empty TenantInfo without touching Azure AD");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #22b failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Replacement for GraphQuery.GetTenantDetail() — instance method, synchronous,
+    /// returns TenantInfo (Microsoft.Dynamics.Nav.LicensingService.Model.TenantInfo).
+    /// Builds an empty TenantInfo directly via reflection (all string properties set to
+    /// string.Empty), matching AzureADGraphQuery.CreateEmptyTenantInfo's own shape for a
+    /// tenant with no AAD tenant id configured — but without depending on that internal
+    /// fallback path (which requires currentSession to be non-null first; see Patch #22's
+    /// header comment for why it never was, for this specific call path).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static object? Replacement_GraphQueryGetTenantDetail(object self)
+    {
+        try
+        {
+            if (_tenantInfoType == null) return null;
+            var tenantInfo = Activator.CreateInstance(_tenantInfoType);
+            foreach (var prop in _tenantInfoType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (prop.PropertyType == typeof(string) && prop.CanWrite)
+                {
+                    prop.SetValue(tenantInfo, string.Empty);
+                }
+            }
+            return tenantInfo;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #22b: failed to build empty TenantInfo: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

ISV extension installs (e.g. Continia OPplus) fail with a misleading error:

```
You must assign at least one user the SUPER permission set and configure
that user to log in with authentication type 'NavUserPassword', which is
supported by the current server instance.
```

This is BC's generic fallback for *any* failed install-transaction commit, not actually about SUPER/NavUserPassword — it was hiding two unrelated bugs. Both needed `BC_DEBUG_FIRSTCHANCE=1` + decompiling `Nav.Ncl.dll` to find, since BC redacts the real exception message.

## Bug 1 — `entrypoint.sh`: wrong "never expires" sentinel

Bootstrap users' `[User].[Expiry Date]` was set to `2099-12-31`. BC's own SUPER-user check filters on `expiryDateField.Equal(NavDateTime.Undefined)`, i.e. the actual sentinel `1753-01-01` — so both bootstrap users were silently excluded from every SUPER-user check. Fixed to use `1753-01-01`, matching the convention already used for `[User Property].[WebServices Key Expiry Date]` two lines below.

## Bug 2 — `StartupHook.cs`: new Patch #22b

`GraphQuery.GetTenantDetail()` (reached via Microsoft's `IsPlanAssignedToUser`, used by several ISV install codeunits) threw a `NullReferenceException` on a null session. Existing Patch #22 hooks `AzureADGraphQuery`'s ctor, but `GraphQuery`'s own parameterless ctor (a separate, lazily-loaded assembly under `Add-ins/GraphClient/`) always passes `null` regardless — so that fix never applied here. Added Patch #22b: hooks the synchronous `GetTenantDetail()` wrapper (not the async `GetTenantDetailAsync`, per Patch #20's own warning about hooking async methods) to return an empty `TenantInfo` directly.

## Verification

Verified end-to-end against a freshly created container: Continia OPplus, its Trial Balance VAT DACH add-on, and its System Application/Core/Connector dependencies all install successfully.