### PR TITLE
Fall back to the base AL package when .Linux ships no compiler

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -697,102 +697,18 @@ jobs:
       - name: Install AL compiler (Linux)
         run: |
           bash bc-linux/scripts/workflow-summary.sh begin AL_INSTALL "Install AL compiler"
-          AL_TOOL="${{ inputs.al_tool_version }}"
-          BC_MAJOR=$(echo "${{ inputs.bc_version }}" | cut -d. -f1)
-          # A policy keyword resolves through the shared script; anything
-          # else is an exact version and is used as-is.
-          case "$AL_TOOL" in
-            ""|matching|latest|prerelease)
-              AL_POLICY="${AL_TOOL:-matching}"
-              AL_TOOL=""
-              ;;
-            *)
-              AL_POLICY=""
-              ;;
-          esac
-          if [ -z "$AL_TOOL" ]; then
-            # Resolved from nuget.org rather than a hardcoded table. AL major
-            # is BC major - 11, and the resolver prefers the newest stable of
-            # that major, falling back to the newest prerelease when no stable
-            # exists. That fallback is what makes a preview BC version
-            # buildable at all: BC 29 needs AL 18.x, and as of 2026-08 there
-            # is no stable 18.x on nuget.org — only 18.0.39.10160-beta.
-            #
-            # The old table covered BC 27 and 28 only; anything else fell
-            # through to a ::warning:: and the BC 27 compiler, which does not
-            # fail loudly — it compiles against the wrong platform and the
-            # errors point somewhere unrelated. The resolver returns the same
-            # versions the table did for 27 and 28, so this is a
-            # generalization of the previous behavior, not a new guess.
-            if ! AL_TOOL=$(python3 bc-linux/scripts/resolve-al-tool-version.py "${{ inputs.bc_version }}" --policy "$AL_POLICY"); then
-              echo "::error::could not resolve an AL compiler version for BC ${{ inputs.bc_version }}"
-              exit 1
-            fi
+          # Resolution, package-shape fallback (Microsoft has been known to
+          # reshuffle where the compiler binary lives inside a BC preview's
+          # AL nupkg without warning — see install-al-compiler.sh's header
+          # for the specific incident this guards against) and the AL
+          # wrapper all live in the shared script so this logic exists in
+          # exactly one place across the reusable workflow and both
+          # examples/ pipelines.
+          if ! INSTALL_OUT=$(bash bc-linux/scripts/install-al-compiler.sh "${{ inputs.bc_version }}" "${{ inputs.al_tool_version }}"); then
+            exit 1
           fi
-          echo "Installing AL compiler $AL_TOOL"
-          PKG="microsoft.dynamics.businesscentral.development.tools.linux"
-          AL_TOOL_DIR=""
-
-          # Try dotnet global tool first (BC 27 / v16 packages ship with
-          # DotnetToolSettings.xml and install correctly this way).
-          # BC 28+ dropped the tool manifest — the package is now a plain
-          # library nupkg and `dotnet tool install` rejects it; fall through
-          # to the nupkg-extraction path in that case.
-          if dotnet tool install -g \
-              Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-              --version "$AL_TOOL" 2>&1 \
-          || dotnet tool update -g \
-              Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-              --version "$AL_TOOL" 2>&1; then
-            echo "Installed as dotnet global tool"
-            echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-            # Locate alc by searching for it rather than assuming a TFM
-            # directory — see the comment on the extraction path below.
-            AL_TOOL_DIR=$(dirname "$(find "$HOME/.dotnet/tools/.store/$PKG" \
-              -type f -name alc 2>/dev/null | sort | tail -1)")
-          else
-            # Not a dotnet tool — download and extract the nupkg directly.
-            echo "Package is not a dotnet global tool; extracting nupkg"
-            EXTRACT_DIR="$HOME/.al-tool-cache/$AL_TOOL"
-            mkdir -p "$EXTRACT_DIR"
-            curl -fsSL \
-              "https://api.nuget.org/v3-flatcontainer/${PKG}/${AL_TOOL}/${PKG}.${AL_TOOL}.nupkg" \
-              -o "$EXTRACT_DIR/pkg.zip"
-            unzip -q -o "$EXTRACT_DIR/pkg.zip" -d "$EXTRACT_DIR"
-            rm "$EXTRACT_DIR/pkg.zip"
-            # Find alc wherever the package puts it. The TFM directory is
-            # NOT stable across AL majors: v17 ships lib/net8.0/alc, v18
-            # ships lib/net10.0/alc (and a lib/net8.0 that holds only the
-            # analyzer DLLs, so a directory test on net8.0 finds the wrong
-            # place and succeeds). Hardcoding net8.0 is what made the BC 29
-            # leg fail with exit 127 — "lib/net8.0/alc: No such file or
-            # directory" — after the compiler version itself resolved fine.
-            #
-            # Sorting picks the highest TFM when several carry an alc.
-            # No runtime install is needed either way: alc is self-contained,
-            # its runtimeconfig.json declares includedFrameworks rather than
-            # frameworks, so it bundles the .NET it needs. Verified for both
-            # v17 (net8.0) and v18 (net10.0).
-            ALC_PATH=$(find "$EXTRACT_DIR" -type f -name alc 2>/dev/null | sort | tail -1)
-            if [ -z "$ALC_PATH" ]; then
-              echo "::error::no 'alc' binary found in $PKG $AL_TOOL."
-              echo "Package contents (directories):"
-              find "$EXTRACT_DIR" -maxdepth 3 -type d | sed 's/^/  /'
-              exit 1
-            fi
-            AL_TOOL_DIR=$(dirname "$ALC_PATH")
-            echo "Found alc at $ALC_PATH"
-            chmod +x "$ALC_PATH" 2>/dev/null || true
-            # Create an AL wrapper so `AL compile ...` works in later steps.
-            # The v16 dotnet tool ships AL.dll which routes the `compile`
-            # subcommand; raw alc doesn't accept it — strip it here.
-            mkdir -p "$HOME/.al-bin"
-            printf '#!/bin/bash\n[ "$1" = compile ] && shift\nexec "%s/alc" "$@"\n' \
-              "$AL_TOOL_DIR" > "$HOME/.al-bin/AL"
-            chmod +x "$HOME/.al-bin/AL"
-            echo "$HOME/.al-bin" >> "$GITHUB_PATH"
-          fi
-
+          eval "$INSTALL_OUT"
+          echo "$AL_BIN_DIR" >> "$GITHUB_PATH"
           echo "AL_TOOL_DIR=$AL_TOOL_DIR" >> "$GITHUB_ENV"
           echo "AL compiler ready: $AL_TOOL_DIR"
           bash bc-linux/scripts/workflow-summary.sh end AL_INSTALL

--- a/.github/workflows/test-snapshot.yml
+++ b/.github/workflows/test-snapshot.yml
@@ -262,16 +262,19 @@ jobs:
         id: publish
         run: |
           set -e
-          AL_VER=$(python3 scripts/resolve-al-tool-version.py "$BC_VERSION" --policy matching)
-          PKG=microsoft.dynamics.businesscentral.development.tools.linux
-          mkdir -p al && curl -fsSL \
-            "https://api.nuget.org/v3-flatcontainer/${PKG}/${AL_VER}/${PKG}.${AL_VER}.nupkg" -o al/pkg.zip
-          unzip -q -o al/pkg.zip -d al && rm al/pkg.zip
-          ALC=$(find al -type f -name alc | sort | tail -1); chmod +x "$ALC"
+          # See install-al-compiler.sh's header for why this can't just
+          # extract the .Linux nupkg and grep for `alc` directly anymore —
+          # Microsoft has already emptied that package of its compiler
+          # binary once for an AL 18 preview build, and the fallback there
+          # is what keeps this working if that lands in a stable release.
+          if ! INSTALL_OUT=$(bash scripts/install-al-compiler.sh "$BC_VERSION" matching); then
+            exit 1
+          fi
+          eval "$INSTALL_OUT"
           mkdir -p symbols
           python3 scripts/stage-symbols.py --app-json extensions/smoke-test/app.json \
             --artifact-dir "$BC_ARTIFACTS_DIR" --out-dir symbols
-          "$ALC" /project:"$PWD/extensions/smoke-test" /packagecachepath:"$PWD/symbols" \
+          "$AL_BIN_DIR/AL" /project:"$PWD/extensions/smoke-test" /packagecachepath:"$PWD/symbols" \
                  /out:"$PWD/smoke-test.app"
           docker compose cp smoke-test.app bc:/tmp/smoke-test.app
           docker compose exec -T bc sh -c '

--- a/examples/azure-pipelines/bc-test-from-source.yml
+++ b/examples/azure-pipelines/bc-test-from-source.yml
@@ -288,92 +288,17 @@ steps:
 
   - bash: |
       bash "$(Agent.BuildDirectory)/bc-linux/scripts/workflow-summary.sh" begin AL_INSTALL "Install AL compiler"
-      TOOL="$(AL_TOOL_VERSION)"
-      BC_MAJOR=$(echo "$(BC_VERSION)" | cut -d. -f1)
-      # A policy keyword ("matching" default, "latest", "prerelease")
-      # resolves through the shared script; anything else is an exact
-      # version and is used as-is. "latest" is the answer when an app
-      # declares a runtime its own major's compiler rejects — e.g.
-      # runtime 16.1 is refused by AL 16.2 but accepted by AL 17.
-      case "$TOOL" in
-        ""|matching|latest|prerelease)
-          AL_POLICY="${TOOL:-matching}"
-          TOOL=""
-          ;;
-        *)
-          AL_POLICY=""
-          ;;
-      esac
-      if [ -z "$TOOL" ]; then
-        # Resolved from nuget.org: AL major is BC major - 11, newest stable of
-        # that major, falling back to the newest prerelease when no stable
-        # exists (a BC version still in preview has no stable compiler).
-        # Calling the shared script rather than keeping a table here means a
-        # new BC release needs no edit to this file.
-        if ! TOOL=$(python3 "$(Agent.BuildDirectory)/bc-linux/scripts/resolve-al-tool-version.py" "$(BC_VERSION)" --policy "$AL_POLICY"); then
-          echo "##vso[task.logissue type=error]Could not resolve an AL compiler version for BC $(BC_VERSION)"
-          exit 1
-        fi
+      # Resolution, package-shape fallback (Microsoft has been known to
+      # reshuffle where the compiler binary lives inside a BC preview's AL
+      # nupkg without warning — see install-al-compiler.sh's header for the
+      # specific incident this guards against) and the AL wrapper all live
+      # in the shared script so this logic exists in exactly one place
+      # across the reusable workflow and both examples/ pipelines.
+      if ! INSTALL_OUT=$(bash "$(Agent.BuildDirectory)/bc-linux/scripts/install-al-compiler.sh" "$(BC_VERSION)" "$(AL_TOOL_VERSION)"); then
+        exit 1
       fi
-      echo "Installing AL compiler $TOOL"
-      PKG="microsoft.dynamics.businesscentral.development.tools.linux"
-      AL_TOOL_DIR=""
-
-      # Try dotnet global tool first (BC 27 / v16 packages ship with
-      # DotnetToolSettings.xml and install correctly this way).
-      # BC 28+ dropped the tool manifest — the package is now a plain
-      # library nupkg and `dotnet tool install` rejects it; fall through
-      # to the nupkg-extraction path in that case. Do NOT swallow the
-      # rejection with `|| true`: without the fallback below there is no
-      # `AL` command at all and the compile step dies with exit 127.
-      if dotnet tool install -g \
-          Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-          --version "$TOOL" 2>&1 \
-      || dotnet tool update -g \
-          Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-          --version "$TOOL" 2>&1; then
-        echo "Installed as dotnet global tool"
-        echo "##vso[task.prependpath]$HOME/.dotnet/tools"
-        # Locate alc by searching, not by assuming a TFM directory.
-        AL_TOOL_DIR=$(dirname "$(find "$HOME/.dotnet/tools/.store/$PKG" \
-          -type f -name alc 2>/dev/null | sort | tail -1)")
-      else
-        # Not a dotnet tool — download and extract the nupkg directly.
-        echo "Package is not a dotnet global tool; extracting nupkg"
-        EXTRACT_DIR="$HOME/.al-tool-cache/$TOOL"
-        mkdir -p "$EXTRACT_DIR"
-        curl -fsSL \
-          "https://api.nuget.org/v3-flatcontainer/${PKG}/${TOOL}/${PKG}.${TOOL}.nupkg" \
-          -o "$EXTRACT_DIR/pkg.zip"
-        unzip -q -o "$EXTRACT_DIR/pkg.zip" -d "$EXTRACT_DIR"
-        rm "$EXTRACT_DIR/pkg.zip"
-        # Find alc wherever the package puts it. The TFM directory is NOT
-        # stable across AL majors: v17 ships lib/net8.0/alc, v18 ships
-        # lib/net10.0/alc plus a lib/net8.0 holding only analyzer DLLs —
-        # so a directory test on net8.0 finds the wrong place and
-        # succeeds. Hardcoding it made the BC 29 leg fail with exit 127.
-        # No runtime install is needed: alc is self-contained (its
-        # runtimeconfig declares includedFrameworks), verified for v17
-        # and v18.
-        ALC_PATH=$(find "$EXTRACT_DIR" -type f -name alc 2>/dev/null | sort | tail -1)
-        if [ -z "$ALC_PATH" ]; then
-          echo "No 'alc' binary found in $PKG $TOOL" >&2
-          find "$EXTRACT_DIR" -maxdepth 3 -type d | sed 's/^/  /' >&2
-          exit 1
-        fi
-        AL_TOOL_DIR=$(dirname "$ALC_PATH")
-        echo "Found alc at $ALC_PATH"
-        chmod +x "$ALC_PATH" 2>/dev/null || true
-        # Create an AL wrapper so `AL compile ...` works in later steps.
-        # The v16 dotnet tool ships AL.dll which routes the `compile`
-        # subcommand; raw alc doesn't accept it — strip it here.
-        mkdir -p "$HOME/.al-bin"
-        printf '#!/bin/bash\n[ "$1" = compile ] && shift\nexec "%s/alc" "$@"\n' \
-          "$AL_TOOL_DIR" > "$HOME/.al-bin/AL"
-        chmod +x "$HOME/.al-bin/AL"
-        echo "##vso[task.prependpath]$HOME/.al-bin"
-      fi
-
+      eval "$INSTALL_OUT"
+      echo "##vso[task.prependpath]$AL_BIN_DIR"
       # Exported so the compile step can point resolve-analyzers.py at
       # the Microsoft cop DLLs — its auto-detection only knows the
       # dotnet-tool layout, not the extracted-nupkg one.

--- a/examples/github-workflows/bc-test-from-source.yml
+++ b/examples/github-workflows/bc-test-from-source.yml
@@ -289,92 +289,18 @@ jobs:
       - name: Install AL compiler (Linux)
         run: |
           bash bc-linux/scripts/workflow-summary.sh begin AL_INSTALL "Install AL compiler"
-          TOOL="$AL_TOOL_VERSION"
-          BC_MAJOR=$(echo "$BC_VERSION" | cut -d. -f1)
-          # A policy keyword ("matching" default, "latest", "prerelease")
-          # resolves through the shared script; anything else is an exact
-          # version and is used as-is. "latest" is the answer when an app
-          # declares a runtime its own major's compiler rejects — e.g.
-          # runtime 16.1 is refused by AL 16.2 but accepted by AL 17.
-          case "$TOOL" in
-            ""|matching|latest|prerelease)
-              AL_POLICY="${TOOL:-matching}"
-              TOOL=""
-              ;;
-            *)
-              AL_POLICY=""
-              ;;
-          esac
-          if [ -z "$TOOL" ]; then
-            # Resolved from nuget.org: AL major is BC major - 11, newest
-            # stable of that major, falling back to the newest prerelease when
-            # no stable exists (a BC version still in preview has no stable
-            # compiler). Calling the shared script rather than keeping a table
-            # here means a new BC release needs no edit to this file.
-            if ! TOOL=$(python3 bc-linux/scripts/resolve-al-tool-version.py "$BC_VERSION" --policy "$AL_POLICY"); then
-              echo "Could not resolve an AL compiler version for BC $BC_VERSION" >&2
-              exit 1
-            fi
+          # Resolution, package-shape fallback (Microsoft has been known to
+          # reshuffle where the compiler binary lives inside a BC preview's
+          # AL nupkg without warning — see install-al-compiler.sh's header
+          # for the specific incident this guards against) and the AL
+          # wrapper all live in the shared script so this logic exists in
+          # exactly one place across the reusable workflow and both
+          # examples/ pipelines.
+          if ! INSTALL_OUT=$(bash bc-linux/scripts/install-al-compiler.sh "$BC_VERSION" "$AL_TOOL_VERSION"); then
+            exit 1
           fi
-          echo "Installing AL compiler $TOOL"
-          PKG="microsoft.dynamics.businesscentral.development.tools.linux"
-          AL_TOOL_DIR=""
-
-          # Try dotnet global tool first (BC 27 / v16 packages ship with
-          # DotnetToolSettings.xml and install correctly this way).
-          # BC 28+ dropped the tool manifest — the package is now a plain
-          # library nupkg and `dotnet tool install` rejects it; fall through
-          # to the nupkg-extraction path in that case. Do NOT swallow the
-          # rejection with `|| true`: without the fallback below there is no
-          # `AL` command at all and the compile step dies with exit 127.
-          if dotnet tool install -g \
-              Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-              --version "$TOOL" 2>&1 \
-          || dotnet tool update -g \
-              Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
-              --version "$TOOL" 2>&1; then
-            echo "Installed as dotnet global tool"
-            echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-            # Locate alc by searching, not by assuming a TFM directory.
-            AL_TOOL_DIR=$(dirname "$(find "$HOME/.dotnet/tools/.store/$PKG" \
-              -type f -name alc 2>/dev/null | sort | tail -1)")
-          else
-            # Not a dotnet tool — download and extract the nupkg directly.
-            echo "Package is not a dotnet global tool; extracting nupkg"
-            EXTRACT_DIR="$HOME/.al-tool-cache/$TOOL"
-            mkdir -p "$EXTRACT_DIR"
-            curl -fsSL \
-              "https://api.nuget.org/v3-flatcontainer/${PKG}/${TOOL}/${PKG}.${TOOL}.nupkg" \
-              -o "$EXTRACT_DIR/pkg.zip"
-            unzip -q -o "$EXTRACT_DIR/pkg.zip" -d "$EXTRACT_DIR"
-            rm "$EXTRACT_DIR/pkg.zip"
-            # Find alc wherever the package puts it. The TFM directory is NOT
-            # stable across AL majors: v17 ships lib/net8.0/alc, v18 ships
-            # lib/net10.0/alc plus a lib/net8.0 holding only analyzer DLLs —
-            # so a directory test on net8.0 finds the wrong place and
-            # succeeds. Hardcoding it made the BC 29 leg fail with exit 127.
-            # No runtime install is needed: alc is self-contained (its
-            # runtimeconfig declares includedFrameworks), verified for v17
-            # and v18.
-            ALC_PATH=$(find "$EXTRACT_DIR" -type f -name alc 2>/dev/null | sort | tail -1)
-            if [ -z "$ALC_PATH" ]; then
-              echo "No 'alc' binary found in $PKG $TOOL" >&2
-              find "$EXTRACT_DIR" -maxdepth 3 -type d | sed 's/^/  /' >&2
-              exit 1
-            fi
-            AL_TOOL_DIR=$(dirname "$ALC_PATH")
-            echo "Found alc at $ALC_PATH"
-            chmod +x "$ALC_PATH" 2>/dev/null || true
-            # Create an AL wrapper so `AL compile ...` works in later steps.
-            # The v16 dotnet tool ships AL.dll which routes the `compile`
-            # subcommand; raw alc doesn't accept it — strip it here.
-            mkdir -p "$HOME/.al-bin"
-            printf '#!/bin/bash\n[ "$1" = compile ] && shift\nexec "%s/alc" "$@"\n' \
-              "$AL_TOOL_DIR" > "$HOME/.al-bin/AL"
-            chmod +x "$HOME/.al-bin/AL"
-            echo "$HOME/.al-bin" >> "$GITHUB_PATH"
-          fi
-
+          eval "$INSTALL_OUT"
+          echo "$AL_BIN_DIR" >> "$GITHUB_PATH"
           # Exported so the compile step can point resolve-analyzers.py at
           # the Microsoft cop DLLs — its auto-detection only knows the
           # dotnet-tool layout, not the extracted-nupkg one.

--- a/scripts/install-al-compiler.sh
+++ b/scripts/install-al-compiler.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# install-al-compiler.sh — Resolve and install the Linux AL compiler for a
+# given BC version, then print the two facts a caller needs as KEY=VALUE
+# lines on stdout:
+#
+#   AL_TOOL_DIR=<dir containing alc (or alc.dll) and the Microsoft cop DLLs>
+#   AL_BIN_DIR=<dir to prepend to PATH; contains an `AL` wrapper script>
+#
+# Usage:
+#   bash scripts/install-al-compiler.sh <bc_version> [al_tool_version_or_policy]
+#
+# al_tool_version_or_policy is either an exact AL nupkg version, or one of
+# the policy keywords resolve-al-tool-version.py understands (matching /
+# latest / prerelease); empty defaults to "matching".
+#
+# All human-readable progress goes to stderr so a caller can safely do:
+#   eval "$(bash scripts/install-al-compiler.sh "$BC_VERSION" "$AL_TOOL")"
+#
+# Why this exists as a shared script rather than inline per-workflow bash:
+# this exact logic used to be duplicated three times (the reusable GitHub
+# workflow, the GitHub Actions example, the Azure Pipelines example) and
+# scripts/check-example-drift.py exists specifically because that kind of
+# duplication rots — a fix landing in one copy and not the other two.
+#
+# Why the extra fallback stage exists: Microsoft has, without warning,
+# emptied the `Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux`
+# nupkg of its `alc` binary for AL 18 betas newer than 18.0.39.10160-beta —
+# the package now ships only the four analyzer cop DLLs and nothing else.
+# Confirmed by downloading both 18.0.39.10160-beta (has lib/net10.0/alc,
+# self-contained) and 18.0.40.43394-beta (lib/net10.0 and lib/net8.0 hold
+# only *Cop.dll files) from nuget.org directly. The actual alc/aldoc/altool/
+# almcp binaries moved to the OS-agnostic base package
+# `Microsoft.Dynamics.BusinessCentral.Development.Tools` (no `.Linux`
+# suffix), under tools/net{8,10}.0/any/ — and there they are
+# framework-dependent (no bundled runtime), not self-contained, unlike
+# every previous package shape this script has had to handle.
+#
+# This is an active preview build reshuffling itself, so BC 29 is the only
+# thing affected today (a non-blocking preview leg — see test-versions.yml).
+# The point of handling it now is that when Microsoft ships this same
+# restructuring in a STABLE release, the fallback below is already in
+# place and nothing here needs to change.
+set -uo pipefail
+
+BC_VERSION="${1:?usage: install-al-compiler.sh <bc_version> [al_tool_version_or_policy]}"
+AL_TOOL="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$AL_TOOL" in
+  ""|matching|latest|prerelease)
+    AL_POLICY="${AL_TOOL:-matching}"
+    AL_TOOL=""
+    ;;
+  *)
+    AL_POLICY=""
+    ;;
+esac
+
+if [ -z "$AL_TOOL" ]; then
+  if ! AL_TOOL=$(python3 "$SCRIPT_DIR/resolve-al-tool-version.py" "$BC_VERSION" --policy "$AL_POLICY"); then
+    echo "::error::could not resolve an AL compiler version for BC $BC_VERSION" >&2
+    exit 1
+  fi
+fi
+echo "Installing AL compiler $AL_TOOL" >&2
+
+LINUX_PKG="microsoft.dynamics.businesscentral.development.tools.linux"
+BASE_PKG="microsoft.dynamics.businesscentral.development.tools"
+
+AL_BIN_DIR="$HOME/.al-bin"
+mkdir -p "$AL_BIN_DIR"
+
+# Every install path below converges on one of these two wrapper shapes,
+# so downstream steps (`AL compile ...`) never need to know whether alc
+# came from a dotnet global tool cache, a directly-extracted .Linux nupkg,
+# or the base-package fallback. The v16 dotnet tool ships AL.dll which
+# routes the `compile` subcommand; raw alc doesn't accept it — both
+# wrappers strip it.
+write_native_wrapper() {
+  # $1 = dir containing a self-contained, executable `alc`
+  printf '#!/bin/bash\n[ "$1" = compile ] && shift\nexec "%s/alc" "$@"\n' "$1" > "$AL_BIN_DIR/AL"
+  chmod +x "$AL_BIN_DIR/AL"
+}
+
+write_dotnet_wrapper() {
+  # $1 = full path to a framework-dependent alc.dll
+  printf '#!/bin/bash\n[ "$1" = compile ] && shift\nexec dotnet "%s" "$@"\n' "$1" > "$AL_BIN_DIR/AL"
+  chmod +x "$AL_BIN_DIR/AL"
+}
+
+# Pick the alc.dll build whose target framework matches an installed
+# runtime, rather than assuming a TFM. Needed because the base-package
+# fallback ships both net8.0 and net10.0 builds side by side and CI only
+# sets up .NET 8 — sorting by name is not a reliable way to prefer a
+# framework that is actually installed (net10.0 sorts before net8.0
+# lexicographically, the opposite of the version order).
+select_dotnet_alc() {
+  # $1 = root dir to search
+  local candidates candidate tfm major fallback=""
+  candidates=$(find "$1" -type f -name alc.dll 2>/dev/null | sort)
+  [ -z "$candidates" ] && return 1
+  while IFS= read -r candidate; do
+    tfm=$(basename "$(dirname "$(dirname "$candidate")")")
+    major=${tfm#net}
+    major=${major%%.*}
+    if dotnet --list-runtimes 2>/dev/null | grep -q "Microsoft\.NETCore\.App ${major}\."; then
+      echo "$candidate"
+      return 0
+    fi
+    fallback="$candidate"
+  done <<< "$candidates"
+  # No installed runtime matched any candidate's TFM — return the last one
+  # found so the caller at least gets a clear "dotnet: framework not
+  # found" error instead of "no alc binary found anywhere", and note it.
+  echo "WARN: found alc.dll but no installed .NET runtime matches its TFM; trying $fallback anyway" >&2
+  echo "$fallback"
+}
+
+AL_TOOL_DIR=""
+
+# --- Attempt 1: dotnet global tool (BC 27 / v16 packages ship with
+# DotnetToolSettings.xml and install correctly this way). BC 28+ dropped
+# the tool manifest — the package is now a plain library nupkg and
+# `dotnet tool install` rejects it; fall through to extraction below.
+if dotnet tool install -g \
+    Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
+    --version "$AL_TOOL" >&2 \
+|| dotnet tool update -g \
+    Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux \
+    --version "$AL_TOOL" >&2; then
+  echo "Installed as dotnet global tool" >&2
+  ALC_PATH=$(find "$HOME/.dotnet/tools/.store/$LINUX_PKG" -type f -name alc 2>/dev/null | sort | tail -1)
+  if [ -n "$ALC_PATH" ]; then
+    AL_TOOL_DIR=$(dirname "$ALC_PATH")
+    write_native_wrapper "$AL_TOOL_DIR"
+  fi
+fi
+
+# --- Attempt 2: extract the .Linux nupkg directly and look for a
+# self-contained alc, wherever the package puts it. The TFM directory is
+# NOT stable across AL majors (v17 lib/net8.0, v18 lib/net10.0, plus a
+# lib/net8.0 in v18 that holds only analyzer DLLs) — search by filename,
+# never assume a path.
+if [ -z "$AL_TOOL_DIR" ]; then
+  echo "Looking for alc in the $LINUX_PKG nupkg" >&2
+  EXTRACT_DIR="$HOME/.al-tool-cache/$AL_TOOL"
+  mkdir -p "$EXTRACT_DIR"
+  if curl -fsSL \
+      "https://api.nuget.org/v3-flatcontainer/${LINUX_PKG}/${AL_TOOL}/${LINUX_PKG}.${AL_TOOL}.nupkg" \
+      -o "$EXTRACT_DIR/pkg.zip"; then
+    unzip -q -o "$EXTRACT_DIR/pkg.zip" -d "$EXTRACT_DIR"
+    rm -f "$EXTRACT_DIR/pkg.zip"
+    ALC_PATH=$(find "$EXTRACT_DIR" -type f -name alc 2>/dev/null | sort | tail -1)
+    if [ -n "$ALC_PATH" ]; then
+      AL_TOOL_DIR=$(dirname "$ALC_PATH")
+      echo "Found alc at $ALC_PATH" >&2
+      chmod +x "$ALC_PATH" 2>/dev/null || true
+      write_native_wrapper "$AL_TOOL_DIR"
+    fi
+  fi
+fi
+
+# --- Attempt 3: the .Linux package has no compiler at all (see the header
+# comment) — fall back to the OS-agnostic base package, which carries a
+# framework-dependent alc.dll under tools/net{8,10}.0/any/ alongside the
+# same cop DLLs resolve-analyzers.py looks for.
+if [ -z "$AL_TOOL_DIR" ]; then
+  echo "$LINUX_PKG has no alc binary for $AL_TOOL; trying the base package $BASE_PKG" >&2
+  BASE_EXTRACT_DIR="$HOME/.al-tool-cache/${AL_TOOL}-base"
+  mkdir -p "$BASE_EXTRACT_DIR"
+  if curl -fsSL \
+      "https://api.nuget.org/v3-flatcontainer/${BASE_PKG}/${AL_TOOL}/${BASE_PKG}.${AL_TOOL}.nupkg" \
+      -o "$BASE_EXTRACT_DIR/pkg.zip"; then
+    unzip -q -o "$BASE_EXTRACT_DIR/pkg.zip" -d "$BASE_EXTRACT_DIR"
+    rm -f "$BASE_EXTRACT_DIR/pkg.zip"
+    ALC_DLL=$(select_dotnet_alc "$BASE_EXTRACT_DIR")
+    if [ -n "$ALC_DLL" ]; then
+      AL_TOOL_DIR=$(dirname "$ALC_DLL")
+      echo "Found framework-dependent alc.dll at $ALC_DLL" >&2
+      write_dotnet_wrapper "$ALC_DLL"
+    fi
+  fi
+fi
+
+if [ -z "$AL_TOOL_DIR" ]; then
+  echo "::error::no alc binary found in either $LINUX_PKG or $BASE_PKG for AL $AL_TOOL." >&2
+  echo "$LINUX_PKG contents:" >&2
+  find "$HOME/.al-tool-cache/$AL_TOOL" -maxdepth 3 -type d 2>/dev/null | sed 's/^/  /' >&2
+  echo "$BASE_PKG contents:" >&2
+  find "$HOME/.al-tool-cache/${AL_TOOL}-base" -maxdepth 3 -type d 2>/dev/null | sed 's/^/  /' >&2
+  exit 1
+fi
+
+echo "AL_TOOL_DIR=$AL_TOOL_DIR"
+echo "AL_BIN_DIR=$AL_BIN_DIR"


### PR DESCRIPTION
## Summary
- Microsoft emptied the `Microsoft.Dynamics.BusinessCentral.Development.Tools.Linux` nupkg of its `alc` binary somewhere between AL `18.0.39.10160-beta` and `18.0.40.43394-beta` (confirmed by downloading both from nuget.org directly) — the package now ships only the four analyzer cop DLLs. This broke the BC 29 preview leg of `test-versions.yml` at the "Install AL compiler" step, before BC ever boots.
- The actual compiler moved to the OS-agnostic base package `Microsoft.Dynamics.BusinessCentral.Development.Tools`, as a framework-dependent `alc.dll` under `tools/net{8,10}.0/any/` (not self-contained like every previous package shape). Added that as a fallback, so a future *stable* BC release shipping this same restructuring doesn't break CI the same way.
- Extracted the install/locate/wrap logic — previously duplicated three times across the reusable workflow and both `examples/` pipelines — into `scripts/install-al-compiler.sh`. `scripts/check-example-drift.py` now enforces that all three stay in sync automatically.
- Also fixed `test-snapshot.yml`, which had its own independent, even more minimal copy of the same fragile "extract `.Linux` nupkg, grep for `alc`" logic (not caught by the drift checker since it isn't one of the three tracked copies).

## Test plan
- [x] `python3 scripts/check-example-drift.py` — passes, no drift
- [x] YAML syntax valid on all four touched workflow/example files
- [x] `bash -n scripts/install-al-compiler.sh` — syntax valid
- [x] Ran `install-al-compiler.sh` directly against the exact failing case (BC 29 / AL `18.0.40.43394-beta`) — finds the compiler via the new fallback, and the resulting `AL` wrapper genuinely compiles ("Microsoft (R) AL Compiler version 18.0.40.43394")
- [x] Ran it against a stable version (BC 28.4) — unaffected, still finds `alc` directly in the `.Linux` package, no fallback triggered
- [x] Full end-to-end simulation of the reusable workflow's step (`GITHUB_PATH`/`GITHUB_ENV` wiring included) against BC 29
- [ ] CI: BC 29 preview leg of `test-versions.yml` should get past "Install AL compiler" (still expected to fail later at NST boot per the documented .NET 10 gap — that's unrelated and tracked separately)

https://claude.ai/code/session_01SrpFJ6tXtPTTginEsxybHp