### PR TITLE
Make the NavUserPassword authentication check opt-in

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -419,6 +419,21 @@ on:
         type: string
         default: ""
 
+      verify_authentication:
+        description: >-
+          Opt-in. When true, runs scripts/test-authentication.sh against
+          the running BC container right after it becomes healthy — a
+          positive/negative NavUserPassword auth check pair that catches
+          a client-services wire-format regression before the
+          publish/smoke steps below run (those would otherwise pass even
+          with a broken or bypassed password check). False (default):
+          the step is skipped — not every consumer of this workflow
+          needs to test authentication on every run, so it doesn't run
+          unless asked for.
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       bc_license:
         description: >-
@@ -1077,11 +1092,11 @@ jobs:
           ./scripts/wait-for-bc-healthy.sh ${{ inputs.health_timeout_minutes }}
           bash scripts/workflow-summary.sh end BC_BOOT
 
-      # Run on every supported/preview version so client-services wire-format
-      # changes fail here instead of silently weakening authentication. This
+      # Opt-in (see verify_authentication input below). When enabled, this
       # must run before the positive-only publish/smoke path: the former
       # Patch #16b made every later step green even with a wrong password.
       - name: Verify NavUserPassword authentication
+        if: ${{ inputs.verify_authentication }}
         working-directory: bc-linux
         run: ./scripts/test-authentication.sh
 

--- a/.github/workflows/test-versions.yml
+++ b/.github/workflows/test-versions.yml
@@ -317,6 +317,11 @@ jobs:
       # constraint as the junit artifact name above) — bc_version already
       # varies per leg, so reuse it.
       artifact_name_suffix: "${{ matrix.bc_version }}-required"
+      # verify_authentication defaults to false for consumers (see the
+      # reusable workflow's input doc) — but bc-linux's own matrix is
+      # exactly the regression gate that check exists for, so opt in here
+      # on every supported version.
+      verify_authentication: true
 
   # ─── Preview matrix: NON-BLOCKING insider legs ──────────────────────────
   #     The next BC major and the next minor, discovered from Microsoft's
@@ -374,6 +379,10 @@ jobs:
       ruleset_file: "extensions/smoke-test/cops.rulset.json"
       enable_external_rulesets: true
       preprocessor_symbols: "SMOKE"
+      # Same reasoning as the required matrix: preview legs are the
+      # earliest place a wire-format regression on a new BC version would
+      # show up.
+      verify_authentication: true
 
   # Puts the "this was expected" framing in the run summary, so a red-ish
   # preview leg in the job list doesn't read as a regression to whoever

--- a/examples/azure-pipelines/bc-test-from-source.yml
+++ b/examples/azure-pipelines/bc-test-from-source.yml
@@ -79,6 +79,11 @@ variables:
   # Example: 'BC27PLUS,BC28PLUS' for a version-gated matrix leg.
   PREPROCESSOR_SYMBOLS: ''
 
+  # Opt-in. Runs a NavUserPassword auth check (positive + negative) right
+  # after BC becomes healthy, before apps are published. Off by default —
+  # most repos don't need to test authentication on every run.
+  VERIFY_AUTHENTICATION: 'false'
+
   # ─── Optional: analyzers + ruleset ───────────────────────────────────
   # All off by default. Set to 'true' / fill in to enable. The compile
   # step fails the pipeline if any cop DLL fails to load (AD0001,
@@ -488,11 +493,13 @@ steps:
   - bash: |
       set -e
       cd "$(Agent.BuildDirectory)/bc-linux"
-      # Run before the positive-only publish/smoke path below, same as the
-      # reusable workflow: this is what catches a client-services wire-format
-      # regression instead of every later step passing with a wrong password.
+      # Opt-in (VERIFY_AUTHENTICATION above). When enabled, this runs before
+      # the positive-only publish/smoke path below, same as the reusable
+      # workflow: catches a client-services wire-format regression instead
+      # of every later step passing with a wrong password.
       ./scripts/test-authentication.sh
     displayName: 'Verify NavUserPassword authentication'
+    condition: eq(variables['VERIFY_AUTHENTICATION'], 'true')
 
   - bash: |
       set -e

--- a/examples/github-workflows/bc-test-from-source.yml
+++ b/examples/github-workflows/bc-test-from-source.yml
@@ -77,6 +77,11 @@ env:
   # Example: "BC27PLUS,BC28PLUS" for a version-gated matrix leg.
   PREPROCESSOR_SYMBOLS: ""
 
+  # Opt-in. Runs a NavUserPassword auth check (positive + negative) right
+  # after BC becomes healthy, before apps are published. Off by default —
+  # most repos don't need to test authentication on every run.
+  VERIFY_AUTHENTICATION: "false"
+
   # ─── Optional: analyzers + ruleset ───────────────────────────────────
   # All off by default. Set to "true" / fill in to enable. The compile
   # step fails the workflow if any cop DLL fails to load (AD0001,
@@ -484,10 +489,12 @@ jobs:
           ./scripts/wait-for-bc-healthy.sh 30
           bash scripts/workflow-summary.sh end BC_BOOT
 
-      # Run before the positive-only publish/smoke path below, same as the
-      # reusable workflow: this is what catches a client-services wire-format
-      # regression instead of every later step passing with a wrong password.
+      # Opt-in (VERIFY_AUTHENTICATION above). When enabled, this runs before
+      # the positive-only publish/smoke path below, same as the reusable
+      # workflow: catches a client-services wire-format regression instead
+      # of every later step passing with a wrong password.
       - name: Verify NavUserPassword authentication
+        if: ${{ env.VERIFY_AUTHENTICATION == 'true' }}
         working-directory: bc-linux
         run: ./scripts/test-authentication.sh
 


### PR DESCRIPTION
## Summary
- The "Verify NavUserPassword authentication" step in the reusable workflow (called by AL-Go pipelines, among others) ran on every invocation with no way to turn it off, even though not every consumer repo needs to test authentication on every run.
- Added a `verify_authentication` input to `bc-test-from-source.yml`, defaulting to `false`, and gated the step on it.
- Mirrored the same opt-in toggle in both standalone example templates (`examples/github-workflows/bc-test-from-source.yml`, `examples/azure-pipelines/bc-test-from-source.yml`).
- `test-versions.yml` (bc-linux's own version matrix) now passes `verify_authentication: true` on both the required and preview legs, so bc-linux keeps testing this itself — that's the regression the check was built to catch.

## Test plan
- [x] YAML syntax validated for all four changed files (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI run on this PR exercises the default (off) path
- [ ] Confirm `test-versions.yml`'s matrix still runs the auth check via the new opt-in flag