### PR TITLE
fix: build ARGS as an array, not a space-joined string, for app-json flags

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -573,15 +573,15 @@ jobs:
           # Microsoft Test Runner and the entrypoint's TestRunnerExtension
           # publish would fail with AL1024 — exactly the bug that broke
           # the bc-copilot-blueprint debugging session before this fix.
-          ARGS="--app-json bc-linux/extensions/TestRunnerExtension/app.json"
+          ARGS=(--app-json bc-linux/extensions/TestRunnerExtension/app.json)
           while IFS= read -r d; do
             [ -z "$d" ] && continue
             if [ -f "project/$d/app.json" ]; then
-              ARGS="$ARGS --app-json project/$d/app.json"
+              ARGS+=(--app-json "project/$d/app.json")
             fi
           done <<< "$APP_DIRS"$'\n'"$TEST_APP_DIRS"
           KEEP_IDS=$(python3 bc-linux/scripts/resolve-keep-app-ids.py \
-            $ARGS \
+            "${ARGS[@]}" \
             --artifact-dir "$BC_ARTIFACTS_DIR")
           echo "Resolved keep set: $KEEP_IDS"
           echo "BC_CLEAR_ALL_APPS=selective" >> "$GITHUB_ENV"
@@ -781,13 +781,13 @@ jobs:
           # versions — the old glob-based staging silently failed
           # whenever an expected app moved (e.g. Tests-TestLibraries
           # under platform/applications/BaseApp/Test/ in BC 27.5).
-          ARGS=""
+          ARGS=()
           while IFS= read -r d; do
             [ -z "$d" ] && continue
-            [ -f "project/$d/app.json" ] && ARGS="$ARGS --app-json project/$d/app.json"
+            [ -f "project/$d/app.json" ] && ARGS+=(--app-json "project/$d/app.json")
           done <<< "$APP_DIRS"$'\n'"$TEST_APP_DIRS"
           python3 bc-linux/scripts/stage-symbols.py \
-            $ARGS \
+            "${ARGS[@]}" \
             --artifact-dir "$BC_ARTIFACTS_DIR" \
             --out-dir symbols \
             || true   # warnings about unresolved deps are non-fatal; AL compile gives the precise error if any


### PR DESCRIPTION
APP_DIRS/TEST_APP_DIRS are now newline-separated (#49) so a folder name
containing a space (e.g. "MainApps/Longhorn Midstream BC Extension")
round-trips correctly through the `while IFS= read -r d` loops. But the
two call sites that build --app-json flags for resolve-keep-app-ids.py
and stage-symbols.py still concatenated them into a single ARGS string
and expanded it unquoted ($ARGS), so the shell re-split the same path on
its internal spaces at the point of use:

  resolve-keep-app-ids.py: error: unrecognized arguments: Midstream BC Extension/app.json

Reproduced live on A-BC-Consulting-Group-Inc/LM-Energy-Partners right
after picking up #49 via the AL-Go side pin bump.

Switches both to bash arrays (ARGS=(...) / "${ARGS[@]}"), matching the
pattern already used by HELPER_ARGS/COMPANY_ARGS elsewhere in this file.

Same pattern also exists in the two examples/ workflow files (not
exercised by the live pinned workflow) - noted as a follow-up, not
included here to keep this fix minimal.

https://claude.ai/code/session_017V2w89jVMjevmAca8Pwg8C