### PR TITLE
fix: don't fail the test step when no test apps were ever configured

### DIFF
--- a/.github/workflows/bc-test-from-source.yml
+++ b/.github/workflows/bc-test-from-source.yml
@@ -1318,10 +1318,16 @@ jobs:
             exit 1
           fi
           if [ "$TESTS_TOTAL" -eq 0 ]; then
-            echo "ERROR: no tests ran (TESTS_TOTAL=0). Either the test app"
-            echo "       failed to install or the test framework didn't see"
-            echo "       any [Test] procedures."
-            exit 1
+            if [ -z "$TEST_APP_DIRS" ]; then
+              # No test apps were ever configured for this project - there was
+              # nothing to run, so zero is the correct result, not a failure.
+              echo "No test apps configured (test_app_dirs is empty) - nothing to test, skipping."
+            else
+              echo "ERROR: no tests ran (TESTS_TOTAL=0). Either the test app"
+              echo "       failed to install or the test framework didn't see"
+              echo "       any [Test] procedures."
+              exit 1
+            fi
           fi
 
       # Upload per-app JUnit XML as a workflow artifact even on test failure


### PR DESCRIPTION
TESTS_TOTAL stays 0 for two very different reasons: a test app that
failed to install/run any [Test] procedures (a real failure), or a
project that legitimately has zero test apps (test_app_dirs empty) -
the only reason to spin up a container at all is running tests, so a
compile-only project consuming this workflow directly still needs the
container path for its build, and TESTS_TOTAL=0 there is expected, not
an error. The unconditional check treated both the same, so any project
with no test apps always failed at this step.

Reproduced via AL-Go's Linux fast lane on
A-BC-Consulting-Group-Inc/LM-Energy-Partners for a project with
testFolders: []. AL-Go's own DetermineProjectsToBuild.psm1 test suite
("leaves linuxCodeunitRange empty when a linuxFastLane project has no
test apps") already documents that a project with no test apps is
expected to still complete the fast lane successfully, so the fix
belongs here, not in AL-Go's eligibility check (I tried that first and
it broke that exact test).

https://claude.ai/code/session_017V2w89jVMjevmAca8Pwg8C