### PR TITLE
fix(StartupHook): platform table captions in Chinese on Linux (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ docker compose build bc && docker compose up -d --wait
 - ~29+ failures from `NSClientCallback.CreateDotNetHandle` NullRef on tests that need a UI session (Camera, Barcode, etc.).
 - Bucket 4 sequential test run previously crashed the container after Tests-Misc due to infinite recursion in Microsoft's `OfficeWordDocumentPictureMerger.ReplaceMissingImageWithTransparentImage` (stack overflow in `Nav.OpenXml`, triggered by `TestSendToEMailAndPDFVendor`). **Fixed by Patch #23** — `ReplaceMissingImageWithTransparentImage` is no-op'd via JMP hook so missing images are left in place and the session survives.
 
+- Platform-table captions (All Profile, User, Company, …) came back in Traditional Chinese inside English error messages (issue #52). Not a session-language problem: on Linux/ICU `CultureInfo.GetCultures` never yields plain `zh-TW`, so BC's `LanguageHelper` had no "CHT" entry and the CaptionML parser filed the Chinese text under the English LCID, first in line. **Fixed by Patch #31** (rebuilds the abbreviation table with the ICU-hidden cultures); `extensions/smoke-test` carries a regression guard. Details in `KNOWN-LIMITATIONS.md`.
+
 When adding a new patch, append it to the numbered list in the `StartupHook.cs` header comment AND `KNOWN-LIMITATIONS.md` if it closes a known failure mode.
 
 ## Extension publish/install architecture (consumer-driven, no hand-curated lists)

--- a/KNOWN-LIMITATIONS.md
+++ b/KNOWN-LIMITATIONS.md
@@ -242,3 +242,33 @@ Patch #22b header comment in `StartupHook.cs` for the full root cause
 (and its dependencies — Continia System Application, Continia Core,
 Continia Connector App — plus its own Trial Balance VAT DACH add-on)
 all install successfully against a freshly created container.
+
+## ~~Platform-table captions come back in Traditional Chinese inside English error messages~~ (FIXED — Patch #31, issue #52)
+
+Symptom: `標題 must have a value in 所有設定檔: 範圍=租用戶, 應用程式識別碼=…, 設定檔識別碼=…. It cannot be zero or empty.`
+The message template is English — the session really is running with
+`GlobalLanguage()=1033` — but every caption belonging to a **platform/virtual
+table** (All Profile, User, Company, their fields and option values) is
+rendered in zh-TW. Base Application tables are unaffected, and forcing
+`GLOBALLANGUAGE(1033)` changes nothing, which is why this looked like a
+session leak and wasn't one.
+
+Root cause, verified against a live 27.0 container by calling Microsoft's own
+code: platform table metadata (embedded System package in
+`Microsoft.BusinessCentral.SystemApp.dll`) carries alphabetically ordered
+CaptionML strings keyed by Windows three-letter names
+(`…;CHT=所有設定檔;…;ENU=All Profile;…`). `LanguageHelper` maps those
+abbreviations to LCIDs from `CultureInfo.GetCultures(AllCultures)`, and on
+Linux (.NET on ICU) Chinese is only enumerated as `zh-Hant-TW`/`zh-Hans-CN`
+with LCID 4096, which BC filters out — plain `zh-TW` (1028, `CHT`) is never
+seen. Unknown abbreviations fall back to 1033, so the Chinese text is stored
+under the English LCID, first in the list, and every first-match lookup for
+1033 returns it. `GetLanguageIdByAbbreviatedName("CHT")` really returned 1033
+and `MultiLanguage.Parse("…CHT=x;…ENU=y").GetText(1033)` really returned `x`.
+
+Patch #31 hooks the `LanguageHelper` constructor and rebuilds its table from
+`WindowsLanguageHelper.AllCultures` plus the cultures ICU hides
+(`zh-TW`, `zh-HK`, `zh-MO`, `zh-SG`, …). All 49 abbreviations used by the
+platform's CaptionML resolve to their Windows LCIDs afterwards; on Windows the
+augmentation is a no-op. Session language selection is untouched, so a test
+that deliberately switches to zh-TW still gets Chinese captions.

--- a/extensions/smoke-test/src/SmokeTest2.Codeunit.al
+++ b/extensions/smoke-test/src/SmokeTest2.Codeunit.al
@@ -26,4 +26,48 @@ codeunit 70001 "BC Linux Smoke Test 2"
     begin
         LibraryAssert.IsTrue(true and not false, 'Boolean logic failed');
     end;
+
+    // Regression guard for GitHub issue #52 / StartupHook Patch #31.
+    // Platform (system/virtual) table captions come from CaptionML strings keyed
+    // by Windows three-letter language names. On Linux (.NET on ICU) the "CHT"
+    // abbreviation was unresolvable and fell back to the English LCID, so every
+    // caption of All Profile / User / Company came back in Traditional Chinese
+    // ("所有設定檔") inside otherwise-English error messages, no matter what the
+    // session language was. Base Application tables were never affected, which
+    // is why only platform tables are checked here. An ASCII check is used
+    // instead of comparing against the exact English caption so a Microsoft
+    // rename does not turn this into a false alarm. RecordRef is used because
+    // this app.json (on purpose, see SmokeTest1) declares no platform/application
+    // dependency, so the platform tables cannot be referenced by name.
+    [Test]
+    procedure TestPlatformTableCaptionsAreEnglish()
+    begin
+        GlobalLanguage(1033);
+        AssertTableCaptionsAscii(2000000006, 'Company');
+        AssertTableCaptionsAscii(2000000120, 'User');
+        AssertTableCaptionsAscii(2000000178, 'All Profile');
+    end;
+
+    local procedure AssertTableCaptionsAscii(TableNo: Integer; Name: Text)
+    var
+        RecRef: RecordRef;
+        i: Integer;
+    begin
+        RecRef.Open(TableNo);
+        AssertAscii(RecRef.Caption(), Name + ' table caption');
+        for i := 1 to RecRef.FieldCount() do
+            AssertAscii(RecRef.FieldIndex(i).Caption(),
+                StrSubstNo('%1 field %2 caption', Name, RecRef.FieldIndex(i).Number));
+        RecRef.Close();
+    end;
+
+    local procedure AssertAscii(Value: Text; What: Text)
+    var
+        i: Integer;
+    begin
+        LibraryAssert.AreNotEqual('', Value, What + ' is empty');
+        for i := 1 to StrLen(Value) do
+            LibraryAssert.IsTrue(Value[i] < 128,
+                StrSubstNo('%1 is not English in an en-US session (issue #52 / Patch #31): "%2"', What, Value));
+    end;
 }

--- a/src/StartupHook/StartupHook.cs
+++ b/src/StartupHook/StartupHook.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -154,6 +155,24 @@ using System.Threading.Tasks;
 ///   request before routing/auth-decision finalization) to register an HttpResponse.OnStarting
 ///   callback that adds the header when the response ends up 401. See PatchNavAuthenticationChallenge
 ///   for the full root-cause writeup and why several other approaches were rejected.
+///
+/// Patch #31: LanguageHelper..ctor (Nav.Types.dll) — issue #52, Chinese captions in English sessions
+///   Platform (system/virtual) table captions ship as CaptionML strings keyed by Windows
+///   three-letter language names ("BGR=…;CHS=…;CHT=所有設定檔;…;ENU=All Profile;…").
+///   MultiLanguage.Parse maps each abbreviation to an LCID through LanguageHelper, whose table
+///   is built from CultureInfo.GetCultures(AllCultures) filtered to cultures with a real LCID.
+///   On Linux (.NET/ICU) Chinese is enumerated only as script-qualified names (zh-Hant-TW,
+///   zh-Hans-CN, …) whose LCID is 4096 (LOCALE_CUSTOM_UNSPECIFIED), so they are filtered out
+///   and "CHT" never enters the table. Unknown abbreviations fall back to DefaultLanguageId
+///   (1033), so the Chinese text is stored under the English LCID — and because CaptionML is
+///   alphabetical and every lookup is first-match, "CHT" shadows "ENU" for EVERY caption
+///   lookup on those tables, regardless of session language (GlobalLanguage was verified 1033).
+///   AL apps are unaffected: their xlf lines resolve LCIDs via CultureInfo.GetCultureInfo(name).
+///   Fix: rebuild the two LanguageHelper dictionaries from WindowsLanguageHelper.AllCultures
+///   plus the script-stripped cultures ICU refuses to enumerate (zh-TW/1028/CHT,
+///   zh-HK/3076/ZHH, …), ordered by LCID exactly like the original iteration. On Windows the
+///   augmentation finds nothing, so the result is identical to the stock table. The session
+///   language is NOT touched: a test that calls GLOBALLANGUAGE(1028) still gets Chinese.
 ///
 /// JMP hooks work ONLY on BC methods (JIT-compiled). BCL methods are ReadyToRun pre-compiled
 /// and cannot be patched this way.
@@ -531,6 +550,14 @@ internal class StartupHook
         {
             Console.WriteLine("[StartupHook] Nav.Types.dll loaded — patching");
             PatchNavTypes(args.LoadedAssembly);
+        }
+
+        // Patch #31: complete LanguageHelper's three-letter language table on ICU (issue #52).
+        // Must be hooked before the lazily-created LanguageHelper singleton is first used;
+        // assembly load is the earliest point, and no code from the assembly has run yet.
+        if (name == "Microsoft.Dynamics.Nav.Types")
+        {
+            PatchLanguageHelperCultureTable(args.LoadedAssembly);
         }
 
         // Patch #15: Remove .NET runtime directory from server-side compiler's assembly probing.
@@ -3779,6 +3806,219 @@ internal class StartupHook
             Console.WriteLine($"[StartupHook] Patch #29 failed: {ex.GetType().Name}: {ex.Message}");
         }
     }
+
+    // ========================================================================
+    // Patch #31: LanguageHelper..ctor — complete the three-letter language table
+    // on ICU (GitHub issue #52: Chinese captions inside English error messages)
+    // ------------------------------------------------------------------------
+    // Symptom: "標題 must have a value in 所有設定檔: 範圍=租用戶, …" — the message
+    // template is English (session language really is 1033) but every caption
+    // of a PLATFORM table (All Profile, User, Company, their fields and option
+    // values) comes back in Traditional Chinese. Base Application tables are
+    // fine.
+    //
+    // Mechanism (all verified against a live 27.0 container):
+    //   * Platform table metadata lives in the System package embedded in
+    //     Microsoft.BusinessCentral.SystemApp.dll. Its captions are CaptionML
+    //     strings keyed by Windows three-letter language names, alphabetically
+    //     ordered: "BGR=…;CHS=…;CHT=所有設定檔;CSY=…;…;ENU=All Profile;…".
+    //   * MultiLanguage.Parse turns each abbreviation into an LCID with
+    //     LanguageHelper.GetLanguageIdByAbbreviatedName, which returns
+    //     NavResourceManager.DefaultLanguageId (1033) for anything it doesn't
+    //     know.
+    //   * LanguageHelper's table comes from WindowsLanguageHelper.AllCultures =
+    //     CultureInfo.GetCultures(AllCultures) filtered by ValidLanguageId
+    //     (1024 ≤ LCID ≤ 61439, LCID % 1024 ≠ 0). On Linux .NET runs on ICU,
+    //     which enumerates Chinese only as script-qualified cultures
+    //     (zh-Hant-TW, zh-Hans-CN, zh-Hant-HK, …) with LCID 4096 — filtered
+    //     out — while plain zh-TW (1028, "CHT") is never enumerated at all.
+    //     Microsoft already special-cases 2052 (zh-CN) and 1034 in
+    //     SpecialCultures; 1028 has no such entry.
+    //   * So "CHT" → 1033, the parsed MultiLanguage holds TWO 1033 entries,
+    //     the Chinese one first, and both MultiLanguage.GetText and
+    //     NCLLookupArray.TryGetValue are first-match. English never wins.
+    //
+    // Fix: hook the private LanguageHelper constructor and fill its two
+    // dictionaries ourselves from AllCultures PLUS the cultures ICU hides
+    // (found by stripping the script subtag from every LCID-less
+    // lang-Script-REGION culture and re-resolving it), iterated in LCID order
+    // exactly like the original. Net effect on 27.0/W1: CHT → 1028 and
+    // ZHH → 3076 (zh-HK, which Windows also picks over zh-Hant/31748); every
+    // other abbreviation in the platform's CaptionML resolves as before. On
+    // Windows the augmentation finds nothing and the table is byte-identical.
+    //
+    // Deliberately NOT done: forcing English. The fix corrects the data, not
+    // the language selection, so GLOBALLANGUAGE(1028) in a test still yields
+    // Chinese captions — which is now the correct answer instead of an
+    // accident.
+    //
+    // Hook target choice: the ctor has a loop and ~120 bytes of IL, so the
+    // JIT will not inline it (Patch #22 already relies on ctor hooks).
+    // LanguageHelper.GetLanguageIdByAbbreviatedName and
+    // WindowsLanguageHelper.GetDistinctCultures are both tiny and would be
+    // inlined into their same-assembly callers, defeating a JMP hook.
+    // ========================================================================
+    private static bool _patchedLanguageHelper;
+    private static Type? _languageHelperType;
+    private static Type? _windowsLanguageHelperType;
+
+    private static void PatchLanguageHelperCultureTable(Assembly navTypes)
+    {
+        if (_patchedLanguageHelper || IsPatchDisabled("31")) return;
+        try
+        {
+            _languageHelperType = navTypes.GetType("Microsoft.Dynamics.Nav.Types.LanguageHelper");
+            _windowsLanguageHelperType = navTypes.GetType("Microsoft.Dynamics.Nav.Types.WindowsLanguageHelper");
+            if (_languageHelperType == null || _windowsLanguageHelperType == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #31: LanguageHelper/WindowsLanguageHelper not found — skipped");
+                return;
+            }
+
+            var ctor = _languageHelperType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, Type.EmptyTypes, null);
+            var namesField = _languageHelperType.GetField("languageThreeLetterNames", BindingFlags.Instance | BindingFlags.NonPublic);
+            var idsField = _languageHelperType.GetField("languageIdsByAbbreviatedNames", BindingFlags.Instance | BindingFlags.NonPublic);
+            var allCulturesField = _windowsLanguageHelperType.GetField("AllCultures", BindingFlags.Static | BindingFlags.Public);
+            if (ctor == null || namesField == null || idsField == null || allCulturesField == null
+                || namesField.FieldType != typeof(Dictionary<int, string>)
+                || idsField.FieldType != typeof(Dictionary<string, int>)
+                || allCulturesField.FieldType != typeof(CultureInfo[]))
+            {
+                // The shape we replicate has changed — better to leave the stock ctor alone
+                // than to construct a LanguageHelper we don't understand.
+                Console.WriteLine("[StartupHook] Patch #31: LanguageHelper shape not recognised — skipped");
+                return;
+            }
+
+            var replacement = typeof(StartupHook).GetMethod(nameof(Replacement_LanguageHelperCtor),
+                BindingFlags.Public | BindingFlags.Static)!;
+            ApplyJmpHook(ctor, replacement, "LanguageHelper..ctor (Patch #31)");
+            _patchedLanguageHelper = true;
+            Console.WriteLine("[StartupHook] Patch #31: LanguageHelper..ctor hooked (ICU-complete language table)");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #31 failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Replaces the private LanguageHelper() constructor. Same algorithm as the
+    /// original (iterate cultures in LCID order, first abbreviation wins), over
+    /// WindowsLanguageHelper.AllCultures plus the cultures ICU does not enumerate.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Replacement_LanguageHelperCtor(object self)
+    {
+        var helperType = _languageHelperType ?? self.GetType();
+        var namesField = helperType.GetField("languageThreeLetterNames", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var idsField = helperType.GetField("languageIdsByAbbreviatedNames", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        // Reading the static field runs WindowsLanguageHelper's cctor if needed — exactly
+        // what the original ctor's first line (AllCultures.Length) does.
+        var allCultures = (CultureInfo[])_windowsLanguageHelperType!
+            .GetField("AllCultures", BindingFlags.Static | BindingFlags.Public)!.GetValue(null)!;
+
+        List<CultureInfo> extras;
+        try
+        {
+            extras = FindCulturesHiddenByIcu(allCultures, ReadPseudoLanguageIds());
+        }
+        catch (Exception ex)
+        {
+            // Never let the augmentation take LanguageHelper down with it; fall back to the
+            // stock table (i.e. the pre-patch behaviour).
+            Console.WriteLine($"[StartupHook] Patch #31: culture augmentation failed, using stock table: {ex.GetType().Name}: {ex.Message}");
+            extras = new List<CultureInfo>();
+        }
+
+        // AllCultures is sorted by LCID (CultureInfoComparer); keep that order after merging so
+        // the "first abbreviation wins" rule picks the same culture Windows would.
+        var merged = allCultures.Concat(extras).OrderBy(c => c.LCID).ToList();
+        var names = new Dictionary<int, string>(merged.Count);
+        var ids = new Dictionary<string, int>(merged.Count);
+        foreach (var culture in merged)
+        {
+            int lcid = culture.LCID;
+            string abbrev = culture.ThreeLetterWindowsLanguageName;
+            // Original: skip when the abbreviation is taken. The LCID guard is extra: the
+            // original's Dictionary.Add would throw on a duplicate LCID, and a throwing
+            // ctor would leave BC without any language table at all.
+            if (ids.ContainsKey(abbrev) || names.ContainsKey(lcid)) continue;
+            names.Add(lcid, abbrev);
+            ids.Add(abbrev, lcid);
+        }
+
+        namesField.SetValue(self, names);
+        idsField.SetValue(self, ids);
+
+        Console.WriteLine(extras.Count == 0
+            ? $"[StartupHook] Patch #31: language table built from {allCultures.Length} cultures (nothing to add on this runtime)"
+            : $"[StartupHook] Patch #31: language table built from {allCultures.Length} cultures + {extras.Count} ICU-hidden: "
+              + string.Join(", ", extras.Select(c => $"{c.Name}/{c.LCID}/{c.ThreeLetterWindowsLanguageName}")));
+    }
+
+    private static int[] ReadPseudoLanguageIds()
+    {
+        try
+        {
+            return _windowsLanguageHelperType?
+                .GetField("PseudoLanguages", BindingFlags.Static | BindingFlags.NonPublic)?
+                .GetValue(null) as int[] ?? Array.Empty<int>();
+        }
+        catch
+        {
+            return Array.Empty<int>();
+        }
+    }
+
+    /// <summary>
+    /// Cultures that Windows NLS enumerates but ICU only exposes under a
+    /// script-qualified name with no LCID: for every lang-Script-REGION culture
+    /// whose LCID is 4096, try lang-REGION. Returns only cultures that carry a
+    /// real Windows LCID and three-letter name and are not already known.
+    /// Empty on Windows, where GetCultures already yields zh-TW, zh-HK, ….
+    /// </summary>
+    internal static List<CultureInfo> FindCulturesHiddenByIcu(IReadOnlyCollection<CultureInfo> known, int[] pseudoLanguageIds)
+    {
+        const int LocaleCustomUnspecified = 4096;
+        var knownNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var knownLcids = new HashSet<int>();
+        foreach (var c in known)
+        {
+            knownNames.Add(c.Name);
+            knownLcids.Add(c.LCID);
+        }
+
+        var result = new List<CultureInfo>();
+        foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
+        {
+            if (culture.LCID != LocaleCustomUnspecified) continue;
+            var parts = culture.Name.Split('-');
+            if (parts.Length != 3 || parts[1].Length != 4) continue; // lang-Script-REGION only
+            var stripped = parts[0] + "-" + parts[2];
+            if (knownNames.Contains(stripped)) continue;
+
+            CultureInfo candidate;
+            try { candidate = CultureInfo.GetCultureInfo(stripped); }
+            catch (CultureNotFoundException) { continue; }
+
+            int lcid = candidate.LCID;
+            // Mirrors WindowsLanguageHelper.ValidLanguageId.
+            if (lcid < 1024 || lcid > 61439 || lcid % 1024 == 0) continue;
+            if (Array.IndexOf(pseudoLanguageIds, lcid) >= 0) continue;
+            if (knownLcids.Contains(lcid)) continue;
+            var abbrev = candidate.ThreeLetterWindowsLanguageName;
+            if (string.IsNullOrEmpty(abbrev) || abbrev == "ZZZ") continue; // no Windows name known
+
+            knownNames.Add(stripped);
+            knownLcids.Add(lcid);
+            result.Add(candidate);
+        }
+        return result;
+    }
+
 
     /// <summary>
     /// Patch #30: the Dev Services (/BC/dev/*) endpoint never sends a WWW-Authenticate


### PR DESCRIPTION
## Summary

Fixes #52. Business Central error messages on platform tables (All Profile, User, Company) showed field and table captions in Traditional Chinese even though the session language was English — for example: `標題 must have a value in 所有設定檔: ...` instead of `Caption must have a value in All Profile: ...`.

## Root cause

Platform table captions ship as `CaptionML` strings keyed by Windows three-letter language codes, for example `CHT=所有設定檔;...;ENU=All Profile`. Business Central resolves each code to a Windows LCID using `.NET`'s `CultureInfo.GetCultures()`.

On Linux, .NET uses ICU instead of the Windows NLS APIs. ICU only exposes Chinese cultures under script-qualified names like `zh-Hant-TW`, which carry a placeholder LCID that Business Central's language table filters out. Because of this, the plain `zh-TW` culture and its `CHT` code never make it into the table. When a code isn't found, it falls back to the English LCID (1033). Since the caption string is alphabetical and the lookup takes the first match, the Chinese text for `CHT` ends up filed under the English LCID and wins over the real English (`ENU`) entry — no matter what language the session is actually running in.

Base Application tables aren't affected, because those resolve captions through xlf translation files instead of this three-letter code table.

## Fix

Patch #31 in `src/StartupHook/StartupHook.cs` hooks the constructor of `LanguageHelper` and rebuilds its lookup table to include the cultures ICU hides (zh-TW, zh-HK, zh-MO, zh-SG, pa-IN), so each three-letter code resolves to its correct LCID. On Windows, the fix finds nothing to add and leaves the table unchanged.

This only corrects the code-to-LCID mapping — it doesn't touch session language selection. A test that calls `GLOBALLANGUAGE(1028)` on purpose still gets Chinese captions.

## Testing

- Reproduced the bug with a minimal AL test that opens the Profile Card page and leaves its Caption field blank — deterministic on a fresh session, no other state involved.
- Rebuilt the image and confirmed the same test now fails with the expected English message: `Caption must have a value in All Profile: ...`.
- Added `TestPlatformTableCaptionsAreEnglish` to `extensions/smoke-test`, which checks that every caption on the All Profile, User, and Company tables is ASCII-only in an English session. All 5 smoke tests pass.