### PR TITLE
fix: stop BC's license teardown from failing a running test session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ docker compose build bc && docker compose up -d --wait
    - **#14, #15, #15a/b**: server-side AL compiler (Cecil) — strip the Windows .NET runtime probing path and fix type-forward resolution so AL extensions actually compile.
    - **#19, #20**: Reporting Service. The Windows PE binary is replaced with `stubs/reporting-service-stub` (Linux .NET), and `CustomReportingServiceClient` is swapped for a no-op so the watchdog stops flooding the log.
    - **#21**: `NavOpenTaskPageAction.ShowForm` no-op — without it, a single test that opens a task page kills the entire test session.
+   - **#32, #32b**: `NavLicense.Dispose(bool)` and `NavDatabaseSecurityAndLicense.Dispose(bool)` no-op'd. A `NavDatabase` teardown concurrent with a running session used to hand that session a `NullReferenceException` from inside Microsoft's `BclLicenseDataReader` (whose `Dispose` is `reader = null` and whose readers are unguarded), or an `ObjectDisposedException` from the `licenseLock`. Both bodies are pure GC bookkeeping. This is the single biggest source of *random* one-test red legs, because the altool `cli` transport starts a fresh session per codeunit — see KNOWN-LIMITATIONS.md.
 
 5. **`extensions/TestRunnerExtension/`** — AL extension (`src/*.al`) exposing the OData/WebSocket pages used by `run-tests.sh`. The compiled `.app` lives in the same dir and is copied into the image at build time (`extensions/TestRunnerExtension/TestRunnerExtension.app` → `/bc/testrunner/TestRunner.app`).
 
@@ -602,6 +603,20 @@ message="...">` with the BC error message in the attribute and the full
 AL call stack in the body. Skipped tests use `<skipped/>`.
 
 ### Things not to break
+
+- **The altool hub's empty-name result is a rollup, not a test.** BC's
+  TestRunnerHub emits one extra result per codeunit with an empty method
+  name (`  PASS  (656ms)` / `  FAIL  (876ms)`). `run-tests-altool.py`
+  drops the PASS form, keeps the FAIL form as `(codeunit)` so a real
+  codeunit-level failure (an OnRun error, a failed codeunit-level setup)
+  cannot vanish — and then **drops that too when a named `[Test]` in the
+  same codeunit already failed** (`CodeunitRun.drop_redundant_codeunit_result`).
+  Without that last step one real failure is reported as two, the JUnit
+  file carries a phantom `(codeunit)` case whose AL call stack points at
+  whichever test ran last (often a passing one), and the altool and
+  websocket runners disagree about the same run — the websocket leg
+  reports 1. Don't "simplify" this back to keeping every empty-name row,
+  and don't drop them unconditionally either; both directions have bitten.
 
 - **`Test Method Line.Name` on Function rows is the function name, not
   the codeunit name.** I expected the table to expose the codeunit name

--- a/KNOWN-LIMITATIONS.md
+++ b/KNOWN-LIMITATIONS.md
@@ -272,3 +272,63 @@ Patch #31 hooks the `LanguageHelper` constructor and rebuilds its table from
 platform's CaptionML resolve to their Windows LCIDs afterwards; on Windows the
 augmentation is a no-op. Session language selection is untouched, so a test
 that deliberately switches to zh-TW still gets Chinese captions.
+
+## ~~Random "Unexpected CLR exception thrown." NullReferenceException on any AL statement~~ (FIXED — Patch #32/#32b)
+
+Symptom: one test in one codeunit, in an otherwise green run, fails with
+
+```
+Unexpected CLR exception thrown.: System.NullReferenceException
+  at BclLicenseDataReader.ILicenseDataReader.TryGetPermissionMask(...)
+  at NavLicense.GetLicensePermissionMask(...)
+  at NavDatabaseSecurityAndLicense.<>c.<.ctor>b__13_0(ApplicationObjectId)
+  at NavDatabaseSecurityAndLicense.GetLicensePermissions(...)
+  at LicensePermissionSet.FetchPermissions()
+  ...
+  at RecordImplementation.VerifyPermissions(...)
+```
+
+The AL frame at the bottom is arbitrary — whatever statement happened to need
+a permission check. Observed on `Record.DeleteAll` inside a fixture-cleanup
+`Initialize`. Rerunning passes. Sibling BC versions on the same commit pass.
+
+Root cause is a use-after-dispose race in Microsoft's own code, not anything
+Linux-specific — there is no Win32 API anywhere in the chain:
+
+```csharp
+// BclLicenseDataReader — the ENTIRE Dispose body
+void IDisposable.Dispose() { reader = null; }
+
+// ...and every accessor, unguarded
+bool TryGetPermissionMask(ObjectType t, int n, out PermissionMask m) {
+    m = PermissionMask.None;
+    var p = reader.GetObjectRangePermission(...);   // NRE
+```
+
+`NavDatabase.Dispose` → `NavDatabaseSecurityAndLicense.Dispose` →
+`NavLicense.Dispose` → that. Meanwhile the reader side is unsynchronized:
+`GetLicensePermissions` holds `licenseLock` only around its memo-cache reads
+and writes, and calls the actual license lookup
+(`NavCurrentThread.Session.License.GetLicensePermissionMask`) between them
+holding nothing. So a database teardown concurrent with a running session
+gives that session an NRE.
+
+bc-linux does not cause the race but is unusually good at provoking it:
+`run-tests-altool.py`'s default `cli` transport starts a fresh BC session per
+codeunit, and `run-tests-hybrid.py` runs a websocket leg concurrently, so
+session start and database teardown overlap continuously for the length of a
+run. One bad landing in a 300-codeunit run reddens the leg.
+
+**Patch #32** no-ops `NavLicense.Dispose(bool)` and **Patch #32b** no-ops
+`NavDatabaseSecurityAndLicense.Dispose(bool)`. Both bodies are teardown
+bookkeeping: `isDisposed` is read nowhere but inside the Dispose that writes
+it, and the owner nulls its own reference regardless, so the object graph
+still becomes unreachable at the same instant. #32b additionally skips
+`ReaderWriterLockSlim.Dispose` — deliberate, because that lock is the other
+half of the same window (a race landing on `EnterReadLock` gets
+`ObjectDisposedException` instead of the NRE), and an undisposed RWLS costs
+at most three finalizer-reclaimed wait events per NavDatabase.
+
+Both patches shape-check the fields they reasoned about and skip themselves
+with a log line if Microsoft changes the type, so a future BC that gives these
+types a real resource to release will not silently leak it.

--- a/scripts/run-tests-altool.py
+++ b/scripts/run-tests-altool.py
@@ -92,7 +92,10 @@ from xml.sax.saxutils import escape, quoteattr
 # live against BC 28.1). Empty-name PASS lines are dropped from the counts
 # (they aren't [Test] procedures and the legacy runner never counted them);
 # empty-name FAIL/SKIP lines are recorded as "(codeunit)" so a codeunit-
-# level failure (e.g. OnRun error) can't vanish silently.
+# level failure (e.g. OnRun error) can't vanish silently. A "(codeunit)"
+# FAIL is then dropped again if a NAMED test in the same codeunit already
+# failed — see CodeunitRun.drop_redundant_codeunit_result; there it is only
+# the rollup of that failure, and keeping it double-counts.
 RESULT_LINE = re.compile(r"^\s{2}(PASS|FAIL|SKIP)\s(.*)\((\d+)ms\)$")
 SUMMARY_LINE = re.compile(
     r"Test run completed: (\d+) passed, (\d+) failed, (\d+) skipped\."
@@ -258,6 +261,33 @@ class CodeunitRun:
         self.started = datetime.now(timezone.utc)
         self.elapsed_seconds = 0.0
 
+    def drop_redundant_codeunit_result(self) -> None:
+        """Drop the "(codeunit)" rollup when a named test already reports the failure.
+
+        The hub emits one extra result per codeunit with an empty method name (see
+        RESULT_LINE). An empty-name PASS is discarded at parse time; an empty-name
+        FAIL is kept as "(codeunit)" so a codeunit-level failure with no named test
+        attached to it — an OnRun error, a failed codeunit-level setup — cannot vanish
+        silently.
+
+        But when a named [Test] procedure in the same codeunit ALSO failed, the rollup
+        is just that failure counted a second time: one real failure is reported as
+        "2 failed", and the JUnit file carries a phantom "(codeunit)" test case whose AL
+        call stack points at whichever test ran last (often one that passed). The
+        websocket runner reports the same codeunit as 1 failure, so the two runners
+        disagree about the same run.
+
+        Keep the rollup only when it is the sole evidence of the failure.
+        """
+        named_failed = any(
+            status == "FAIL" and name != "(codeunit)" for status, name, _, _ in self.results
+        )
+        if not named_failed:
+            return
+        self.results = [
+            r for r in self.results if not (r[0] == "FAIL" and r[1] == "(codeunit)")
+        ]
+
 
 def run_codeunit(
     altool_cmd: str,
@@ -361,6 +391,7 @@ def run_codeunit(
             run.error = f"unrecognized al runtests output: {tail}"
         else:
             run.error = "no test results returned for a Subtype=Test codeunit"
+    run.drop_redundant_codeunit_result()
     return run
 
 
@@ -839,6 +870,9 @@ def run_codeunits_via_hub(
 
             if run.error:
                 print(f"    ERROR: {run.error}")
+            # Applies on every exit path above, including the timeout /
+            # connection-lost ones that carry partial results.
+            run.drop_redundant_codeunit_result()
             runs.append(run)
             i += 1
 

--- a/src/StartupHook/StartupHook.cs
+++ b/src/StartupHook/StartupHook.cs
@@ -174,6 +174,44 @@ using System.Threading.Tasks;
 ///   augmentation finds nothing, so the result is identical to the stock table. The session
 ///   language is NOT touched: a test that calls GLOBALLANGUAGE(1028) still gets Chinese.
 ///
+/// Patch #32: NavLicense.Dispose(bool) (Nav.Ncl.dll) — license teardown races an active session
+///   NavDatabase.Dispose tears down its NavDatabaseSecurityAndLicense, which disposes the
+///   NavLicense, which does `dataReader?.Dispose(); dataReader = null;`. BclLicenseDataReader
+///   .Dispose is literally `reader = null;` and every one of its readers — TryGetPermissionMask
+///   included — dereferences `reader` with no null check. Meanwhile
+///   NavDatabaseSecurityAndLicense.GetLicensePermissions calls getLicenseFunc (→
+///   NavCurrentThread.Session.License.GetLicensePermissionMask) OUTSIDE its licenseLock. So a
+///   database torn down while a session is still executing AL gives that session a
+///   NullReferenceException inside BclLicenseDataReader.TryGetPermissionMask — surfaced to the
+///   test runner as "Unexpected CLR exception thrown." on whatever statement happened to need a
+///   permission check (observed: ALTFixtureCleanup.Initialize → Record.DeleteAll).
+///   Not Linux-specific — nothing in the path is a Win32 API — but bc-linux provokes it hard:
+///   the altool runner's `cli` transport opens a fresh session per codeunit, and the hybrid
+///   runner runs a second websocket leg concurrently, so database teardown and session start
+///   overlap constantly. One flaky failure in a 315-codeunit run is enough to redden a leg.
+///   Fix: no-op Dispose(bool). Its entire body is GC bookkeeping — no unmanaged resource, no
+///   handle, and `isDisposed` is read nowhere but inside Dispose itself. The owning
+///   NavDatabaseSecurityAndLicense nulls its own `license` field regardless, so the whole graph
+///   still becomes unreachable at the same instant; nothing is retained. A session that races
+///   the teardown now reads a still-valid license instead of crashing.
+///   Method body verified byte-identical on BC 27.0, 28.0 and 28.4.
+///
+/// Patch #32b: NavDatabaseSecurityAndLicense.Dispose(bool) (Nav.Ncl.dll)
+///   The same teardown, one frame out, and the sibling of the window #32 closes.
+///   GetLicensePermissions brackets its memo-cache with licenseLock.EnterReadLock() /
+///   EnterUpgradeableReadLock(); Dispose calls licenseLock.Dispose() from the teardown
+///   thread. So a race that lands on either Enter gets ObjectDisposedException
+///   (ReaderWriterLockSlim) rather than the NullReferenceException #32 fixes — same trigger,
+///   same session, different exception. Fixing only #32 would swap one flake for another.
+///   Fix: no-op Dispose(bool). Unlike #32 this one DOES skip a real Dispose call — the
+///   ReaderWriterLockSlim's. That is acceptable and deliberate: RWLS holds no OS handle of
+///   its own, only up to three lazily-created wait events that the finalizer reclaims, there
+///   is exactly one lock per NavDatabase, and the object graph still becomes unreachable when
+///   NavDatabase drops it. `isDisposed` is read nowhere but inside Dispose itself, the type
+///   has no subclasses (so hooking the base cannot be bypassed by an override), and `license
+///   = null` is redundant once the owner is going away.
+///   Method body verified byte-identical on BC 27.0 and 28.0.
+///
 /// JMP hooks work ONLY on BC methods (JIT-compiled). BCL methods are ReadyToRun pre-compiled
 /// and cannot be patched this way.
 ///
@@ -600,6 +638,15 @@ internal class StartupHook
         if (name == "Microsoft.Dynamics.Nav.Ncl")
         {
             PatchNavFileExpandFileName(args.LoadedAssembly);
+        }
+
+        // Patch #32: NavLicense.Dispose(bool) races an in-flight session's permission check
+        // and hands it a NullReferenceException from BclLicenseDataReader. No-op the dispose;
+        // it is pure GC bookkeeping. See the header comment for the full chain.
+        if (name == "Microsoft.Dynamics.Nav.Ncl")
+        {
+            PatchNavLicenseDispose(args.LoadedAssembly);
+            PatchNavDatabaseSecurityAndLicenseDispose(args.LoadedAssembly);
         }
 
         // Patch #21: NavOpenTaskPageAction.ShowForm crashes on Linux when a test opens a
@@ -3761,6 +3808,191 @@ internal class StartupHook
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static object? Replacement_ReturnNull_1Arg(object? self) { return null; }
+
+    /// <summary>
+    /// No-op replacement for an instance `void Dispose(bool)`. The receiver arrives as the
+    /// first explicit argument; the bool is ignored.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Replacement_NoOp_ObjectBool(object self, bool disposing) { }
+
+    // ========================================================================
+    // Patch #32: NavLicense.Dispose(bool) — stop license teardown from killing
+    // an in-flight session's permission check
+    // ------------------------------------------------------------------------
+    // The chain, all inside Nav.Ncl:
+    //
+    //   NavDatabase.Dispose(bool)
+    //     -> NavDatabaseSecurityAndLicense.Dispose(bool)
+    //          licenseLock.Dispose();
+    //          license.Dispose(); license = null;
+    //     -> NavLicense.Dispose(bool)
+    //          dataReader?.Dispose(); dataReader = null;
+    //     -> BclLicenseDataReader.IDisposable.Dispose()
+    //          reader = null;                      // that is the ENTIRE body
+    //
+    // and on the reader side, every accessor dereferences `reader` unguarded:
+    //
+    //   bool TryGetPermissionMask(ObjectType t, int n, out PermissionMask m) {
+    //       m = PermissionMask.None;
+    //       var p = reader.GetObjectRangePermission(...);   // NRE once disposed
+    //
+    // The two sides are not serialized against each other. NavDatabaseSecurityAndLicense
+    // .GetLicensePermissions takes licenseLock only around its memo-cache reads and
+    // writes; the actual license lookup —
+    //   getLicenseFunc = id => NavCurrentThread.Session.License.GetLicensePermissionMask(...)
+    // — runs between the read lock and the upgradeable read lock, holding nothing. So a
+    // NavDatabase teardown concurrent with a running session hands that session a
+    // NullReferenceException from inside Microsoft's license reader, on whatever AL
+    // statement happened to trigger a permission check.
+    //
+    // Fix: no-op Dispose(bool). Justification for why that is free rather than a leak:
+    //
+    //   * The body releases nothing. There is no unmanaged resource, no OS handle, no
+    //     finalizer to suppress beyond the GC.SuppressFinalize the public Dispose() already
+    //     does. Setting fields to null is a GC hint, not a release.
+    //   * `isDisposed` is read in exactly one place — Dispose(bool) itself (verified with a
+    //     field-usage scan across the assembly). Nothing else changes behaviour once the
+    //     license is "disposed", so skipping the flag is not observable.
+    //   * The owner drops the reference anyway: NavDatabaseSecurityAndLicense.Dispose sets
+    //     its own `license` field to null immediately after. The NavLicense, its dataReader
+    //     and the parsed license content therefore become unreachable at the same moment
+    //     they would have before — the graph is collected, just one hop later.
+    //
+    // Net effect: a session that races the teardown reads a still-valid license and gets
+    // the correct permission mask, instead of dying.
+    //
+    // Not a Linux-specific defect — no Win32 surface anywhere in the chain — but bc-linux
+    // is unusually good at provoking it. run-tests-altool.py's default `cli` transport
+    // starts a fresh BC session per codeunit, and run-tests-hybrid.py runs a websocket leg
+    // concurrently, so session start and database teardown overlap continuously for the
+    // length of a run. Observed as a one-off red leg on BC 28.0 in a 315-codeunit run while
+    // seven sibling legs on the same commit passed.
+    //
+    // Applied on every BC version. Method body verified byte-identical on 27.0, 28.0, 28.4.
+    // ========================================================================
+    private static void PatchNavLicenseDispose(Assembly navNcl)
+    {
+        if (IsPatchDisabled("32")) return;
+        try
+        {
+            var type = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavLicense");
+            if (type == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32: NavLicense type not found — skipping");
+                return;
+            }
+
+            var dispose = type.GetMethod("Dispose",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                binder: null, types: new[] { typeof(bool) }, modifiers: null);
+            if (dispose == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32: NavLicense.Dispose(bool) not found — skipping");
+                return;
+            }
+
+            // Shape check: only hook while the body is still the "null the fields" form we
+            // reasoned about. If Microsoft ever gives NavLicense a real resource to release,
+            // the field set changes and we back off rather than leak it.
+            var dataReaderField = type.GetField("dataReader",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (dataReaderField == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32: NavLicense.dataReader field shape changed — skipping");
+                return;
+            }
+
+            var replacement = typeof(StartupHook).GetMethod(
+                nameof(Replacement_NoOp_ObjectBool),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            ApplyJmpHook(dispose, replacement, "NavLicense.Dispose (Patch #32)");
+            Console.WriteLine("[StartupHook] Patch #32: NavLicense.Dispose(bool) no-op'd (license teardown vs. in-flight session)");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #32 failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    // ========================================================================
+    // Patch #32b: NavDatabaseSecurityAndLicense.Dispose(bool) — the lock half of #32
+    // ------------------------------------------------------------------------
+    //   protected virtual void Dispose(bool disposing) {
+    //       if (!isDisposed && disposing) {
+    //           if (licenseLock != null) licenseLock.Dispose();
+    //           if (license != null) { license.Dispose(); license = null; }
+    //           isDisposed = true;
+    //       }
+    //   }
+    //
+    // GetLicensePermissions runs licenseLock.EnterReadLock() … ExitReadLock(), then the
+    // unlocked license lookup that Patch #32 protects, then EnterUpgradeableReadLock() …
+    // EnterWriteLock(). Patch #32 only covers the middle step. A teardown that wins the race
+    // against either Enter throws ObjectDisposedException from ReaderWriterLockSlim instead —
+    // same trigger, same session, a differently-spelled flake. Both halves have to go.
+    //
+    // Unlike #32, this one does skip a genuine Dispose: the ReaderWriterLockSlim's. Why that
+    // is an acceptable trade rather than a leak:
+    //
+    //   * ReaderWriterLockSlim owns no OS handle directly. Its Dispose releases up to three
+    //     lazily-created wait events, which the finalizer reclaims anyway. Most .NET code
+    //     never disposes one at all.
+    //   * There is one per NavDatabase, not one per session or per request.
+    //   * `license = null` and `isDisposed = true` are bookkeeping. `isDisposed` is read in
+    //     exactly one place — this method (verified by field-usage scan). The owning
+    //     NavDatabase drops its securityAndLicense reference regardless, so the lock, the
+    //     license, the dataReader and the permission memo all become unreachable together.
+    //   * NavDatabaseSecurityAndLicense has no derived types in Nav.Ncl (checked), so hooking
+    //     this `protected virtual` cannot be routed around by an override.
+    //
+    // Applied on every BC version. Method body verified byte-identical on 27.0 and 28.0.
+    // ========================================================================
+    private static void PatchNavDatabaseSecurityAndLicenseDispose(Assembly navNcl)
+    {
+        if (IsPatchDisabled("32b")) return;
+        try
+        {
+            var type = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavDatabaseSecurityAndLicense");
+            if (type == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32b: NavDatabaseSecurityAndLicense type not found — skipping");
+                return;
+            }
+
+            var dispose = type.GetMethod("Dispose",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                binder: null, types: new[] { typeof(bool) }, modifiers: null);
+            if (dispose == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32b: NavDatabaseSecurityAndLicense.Dispose(bool) not found — skipping");
+                return;
+            }
+
+            // Shape check: back off if the fields we reasoned about are gone — a changed
+            // field set is the signal that Microsoft gave this type a real resource to
+            // release, and skipping it would then be a genuine leak rather than a hint.
+            var lockField = type.GetField("licenseLock",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var licenseField = type.GetField("license",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (lockField == null || licenseField == null)
+            {
+                Console.WriteLine("[StartupHook] Patch #32b: NavDatabaseSecurityAndLicense field shape changed — skipping");
+                return;
+            }
+
+            var replacement = typeof(StartupHook).GetMethod(
+                nameof(Replacement_NoOp_ObjectBool),
+                BindingFlags.Static | BindingFlags.NonPublic)!;
+            ApplyJmpHook(dispose, replacement, "NavDatabaseSecurityAndLicense.Dispose (Patch #32b)");
+            Console.WriteLine("[StartupHook] Patch #32b: NavDatabaseSecurityAndLicense.Dispose(bool) no-op'd (licenseLock teardown vs. in-flight session)");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[StartupHook] Patch #32b failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
 
     // ========================================================================
     // Patch #29: NavDirectorySecurity.CreateSecurityForDomainDirectory


### PR DESCRIPTION
## The problem

A test could fail with `Unexpected CLR exception thrown.: System.NullReferenceException` on any AL statement that needs a permission check. Rerunning passed, and the other BC versions on the same commit passed, so it looked like infrastructure noise. Seen most recently on the BC 28.0 leg of [BusinessCentral.AL.Language.Tests#138](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/138).

```
at BclLicenseDataReader.ILicenseDataReader.TryGetPermissionMask(...)
at NavLicense.GetLicensePermissionMask(...)
at NavDatabaseSecurityAndLicense.GetLicensePermissions(...)
at LicensePermissionSet.FetchPermissions()
...
at RecordImplementation.VerifyPermissions(...)
```

## Cause

A use-after-dispose race in Microsoft's own code. `BclLicenseDataReader.Dispose()` is `reader = null;` and nothing else, and every accessor reads `reader` with no null check. `NavDatabase.Dispose` reaches it through `NavDatabaseSecurityAndLicense.Dispose` and `NavLicense.Dispose`. On the reading side, `GetLicensePermissions` holds `licenseLock` only around its cache reads and writes -- the license lookup itself runs between the two locked sections holding nothing.

Nothing in that path is a Windows API, so this is not a Linux defect. But this project runs into it often: the altool `cli` transport starts a new BC session for every codeunit, and the hybrid runner runs a websocket leg at the same time, so session startup and database teardown overlap for the whole run.

## Changes

- **Patch #32 / #32b** make `NavLicense.Dispose(bool)` and `NavDatabaseSecurityAndLicense.Dispose(bool)` do nothing. Both bodies only null out fields and set an `isDisposed` flag read in one place: the same method that writes it. The owner drops its reference either way, so nothing is retained. #32b also skips `ReaderWriterLockSlim.Dispose` on purpose -- that lock is the other half of the same window, where a race produces `ObjectDisposedException` instead. Fixing only #32 would replace one intermittent failure with another. Both patches check the fields they depend on and skip themselves with a log line if a future BC changes the type.
- **Counting fix in `run-tests-altool.py`.** The hub sends one extra result per codeunit with an empty method name. When a named `[Test]` in the same codeunit had already failed, keeping that rollup counted the same failure twice and added a `(codeunit)` JUnit case whose call stack pointed at a passing test. It is now dropped in that case and kept when it is the only evidence of a failure.

## Test plan

- [x] Both patches apply; BC 28.0 starts and publishes extensions
- [x] 157 codeunits / 1730 tests through the altool `cli` transport: no `BclLicenseDataReader`, no `ObjectDisposedException`
- [x] A/B against `BC_DISABLE_PATCHES=32,32b`: name-for-name identical failures, so the patches change no test outcome
- [x] Counting fix on that run: 11 named failures + 3 empty-name rollups reported as 11, no phantom JUnit cases

This is a race, so a green CI run is not proof. The A/B shows the patches are safe and the mechanism is closed off; the real confirmation is that the intermittent failure stops recurring.

https://claude.ai/code/session_01UEDhfuNxrfpqUABMJPCYrz
