### PR TITLE
fix(#57): close a false-green path — re-opened against master after #58 merged into a stale base

### DIFF
--- a/scripts/run-tests-hybrid.py
+++ b/scripts/run-tests-hybrid.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -154,7 +155,20 @@ def _run_websocket(args, codeunit_ids: list[int], junit_path: str) -> _RunnerRes
     return r
 
 
-def merge_junit(paths: list[str], out_path: str, total_elapsed: float) -> None:
+# One <testsuite> per codeunit that ever got a CodeunitRun/RecordedResult,
+# named "Codeunit <id>" by both write_junit (run-tests-altool.py) and
+# JUnitWriter.Write (tools/TestRunner) — matches regardless of PASS, FAIL,
+# or "produced zero results, here is why" placeholder. Only a codeunit whose
+# id was silently dropped somewhere between dispatch and the report is
+# missing here.
+_SUITE_CODEUNIT_ID = re.compile(r"^Codeunit (\d+)$")
+
+
+def merge_junit(paths: list[str], out_path: str, total_elapsed: float) -> set[int]:
+    """Merge per-runner JUnit files into one, write it, and return the
+    codeunit ids that produced a <testsuite> in the result — the input a
+    completeness check needs. "The merged total is non-zero" cannot see a
+    codeunit that was dispatched but never came back at all; this can."""
     suites: list[ET.Element] = []
     for p in paths:
         if not p or not os.path.isfile(p):
@@ -180,13 +194,18 @@ def merge_junit(paths: list[str], out_path: str, total_elapsed: float) -> None:
             "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         },
     )
+    seen_ids: set[int] = set()
     for s in suites:
         merged.append(s)
+        m = _SUITE_CODEUNIT_ID.match(s.get("name") or "")
+        if m:
+            seen_ids.add(int(m.group(1)))
 
     parent = os.path.dirname(out_path)
     if parent:
         os.makedirs(parent, exist_ok=True)
     ET.ElementTree(merged).write(out_path, encoding="unicode", xml_declaration=True)
+    return seen_ids
 
 
 def main() -> int:
@@ -275,30 +294,60 @@ def main() -> int:
         print(f"--- {name} runner output ---")
         print(r.stdout)
 
+    # Merge — and check completeness — unconditionally, even when
+    # --junit-output wasn't requested: the merged codeunit-id set is how a
+    # dropped codeunit gets caught, not just how the file gets written.
+    junit_paths = [r.junit_path for r in results.values() if r.junit_path]
+    merged_out = args.junit_output or "/tmp/run-tests-hybrid-merged-junit.xml"
+    seen_ids = merge_junit(junit_paths, merged_out, total_elapsed)
     if args.junit_output:
-        junit_paths = [r.junit_path for r in results.values() if r.junit_path]
-        merge_junit(junit_paths, args.junit_output, total_elapsed)
         print(f"Merged JUnit XML written to {args.junit_output}")
-        for p in (hub_junit, ws_junit):
-            try:
-                os.remove(p)
-            except OSError:
-                pass
+    for p in (hub_junit, ws_junit):
+        try:
+            os.remove(p)
+        except OSError:
+            pass
+    if not args.junit_output:
+        try:
+            os.remove(merged_out)
+        except OSError:
+            pass
 
     # Aggregate counts straight from the merged JUnit so the summary line
     # matches exactly what got written, rather than re-parsing two
     # differently-shaped stdout formats.
     total = passed = failed = skipped = errors = 0
-    if args.junit_output and os.path.isfile(args.junit_output):
-        root = ET.parse(args.junit_output).getroot()
+    if os.path.isfile(merged_out):
+        root = ET.parse(merged_out).getroot()
         total = int(root.get("tests", "0"))
         failed = int(root.get("failures", "0"))
         errors = int(root.get("errors", "0"))
         skipped = int(root.get("skipped", "0"))
         passed = total - failed - skipped - errors
-    else:
-        # No JUnit requested — fall back to exit codes only, no counts.
-        pass
+
+    # Completeness: every id in all_ids was dispatched to exactly one of
+    # hub_ids/ws_ids (discover_test_codeunits already intersected any
+    # --codeunit-range filter and reflects only what actually compiled into
+    # this .app, so all_ids IS the exact expected set — nothing legitimate
+    # is missing from it). A codeunit missing a <testsuite> entry never ran
+    # ANYTHING, including any infrastructure-error placeholder a runner
+    # would otherwise have recorded for it — that only happens when a
+    # runner's own early-exit path drops it before ever creating a
+    # CodeunitRun. "total != 0" cannot see this; it can look completely
+    # healthy while codeunits are missing (see
+    # https://github.com/StefanMaron/MsDyn365Bc.On.Linux/issues/57).
+    missing_ids = sorted(set(all_ids) - seen_ids)
+    if missing_ids:
+        missing_hub = sorted(set(hub_ids) & set(missing_ids))
+        missing_ws = sorted(set(ws_ids) & set(missing_ids))
+        print("")
+        print(f"ERROR: {len(missing_ids)} of {len(all_ids)} codeunit(s) produced NO result "
+              f"at all — no <testsuite>, not even a failure — in the merged report: "
+              f"{_ids_str(missing_ids)}")
+        if missing_hub:
+            print(f"       {len(missing_hub)} from the fast path (altool/hub): {_ids_str(missing_hub)}")
+        if missing_ws:
+            print(f"       {len(missing_ws)} from the slow path (websocket): {_ids_str(missing_ws)}")
 
     print("")
     # Keep this exact shape — bc-test-from-source.yml greps
@@ -312,7 +361,9 @@ def main() -> int:
     )
     if any_runner_failed:
         return 1
-    if args.junit_output and total == 0:
+    if missing_ids:
+        return 1
+    if total == 0:
         print("ERROR: no tests ran")
         return 1
     return 0

--- a/scripts/test-infrastructure-retry.py
+++ b/scripts/test-infrastructure-retry.py
@@ -1,15 +1,33 @@
 #!/usr/bin/env python3
-"""Self-test for run-tests-altool.py's infrastructure-retry gate.
+"""Self-test for the run-tests-hybrid.py / run-tests-altool.py / TestRunner
+completeness-and-retry machinery: two mechanisms from issues #55 and #57,
+tested together because they answer the same question from opposite ends —
+"did every dispatched codeunit come back with a result" — and a fixture that
+proves one without the other would miss exactly the gap between them.
 
-The gate decides whether a codeunit that produced no results may be re-run.
-Getting it wrong in one direction re-runs a real failure until it passes; in
-the other it leaves the CI flake this was written for in place. Both are
-silent, so the gate gets a test.
+1. run-tests-altool.py's infrastructure-retry gate (#55). Decides whether a
+   codeunit that produced no results may be re-run. Getting it wrong in one
+   direction re-runs a real failure until it passes; in the other it leaves
+   the CI flake this was written for in place. Both are silent, so the gate
+   gets a test.
 
-The canned stdout blocks below are real `al runtests` output captured from
-StefanMaron/BusinessCentral.AL.Language.Tests CI:
-  - run 33962072138, BC 28.4 leg, codeunit 60064
-  - run 33964397715, BC 28.0 leg, codeunits 60069 (failed) and 60070 (passed)
+   The canned stdout blocks below are real `al runtests` output captured
+   from StefanMaron/BusinessCentral.AL.Language.Tests CI:
+     - run 33962072138, BC 28.4 leg, codeunit 60064
+     - run 33964397715, BC 28.0 leg, codeunits 60069 (failed), 60070 (passed)
+
+2. run-tests-hybrid.py's completeness check (#57). "The merged total is
+   non-zero" cannot see a codeunit that was dispatched but never produced a
+   result at all — not even a failure. That is a path to a FALSE GREEN, not
+   a false red. It has not been observed producing a green leg with
+   codeunits missing — the one real instance so far (corpus PR #146, run
+   33957903095) aborted at the very first codeunit of its websocket leg, so
+   that leg contributed 0 tests and the overall run still exited non-zero.
+   The gap is reachable, not observed: the exact same abort landing after
+   even one codeunit had already passed would leave the merged summary
+   reading "N passed, 0 failed" while every codeunit after it went
+   unreported — nothing before this fix would catch that. This test pins
+   the mechanism the fix adds, not a reproduction of an observed failure.
 
 Run: python3 scripts/test-infrastructure-retry.py
 """
@@ -18,11 +36,17 @@ import importlib.util
 import os
 import subprocess
 import sys
+import tempfile
+import xml.etree.ElementTree as ET
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _spec = importlib.util.spec_from_file_location("altool", os.path.join(_HERE, "run-tests-altool.py"))
 altool = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(altool)
+
+_hybrid_spec = importlib.util.spec_from_file_location("hybrid", os.path.join(_HERE, "run-tests-hybrid.py"))
+hybrid = importlib.util.module_from_spec(_hybrid_spec)
+_hybrid_spec.loader.exec_module(hybrid)
 
 
 class _FakeCompleted:
@@ -80,6 +104,65 @@ UNRECOGNISED = """Some output nobody has seen before
 and no summary line at all"""
 
 
+def _write_junit(path: str, codeunit_ids: list[int]) -> None:
+    """A minimal per-leg JUnit file with one passing <testsuite> per id — the
+    shape both write_junit (run-tests-altool.py) and JUnitWriter.Write
+    (tools/TestRunner) actually produce for a codeunit that ran cleanly."""
+    root = ET.Element("testsuites", {"name": "leg", "tests": str(len(codeunit_ids)),
+                                      "failures": "0", "errors": "0", "skipped": "0",
+                                      "time": "0.0"})
+    for cuid in codeunit_ids:
+        ET.SubElement(root, "testsuite", {
+            "name": f"Codeunit {cuid}", "tests": "1", "failures": "0",
+            "errors": "0", "skipped": "0", "time": "0.1",
+            "timestamp": "2026-09-05T00:00:00Z",
+        })
+    ET.ElementTree(root).write(path, encoding="unicode", xml_declaration=True)
+
+
+def check_hybrid_completeness(check) -> None:
+    """Drive the REAL merge_junit over fixture per-leg JUnit files simulating
+    exactly the shape that dropped codeunit 60064/60069/60942 would have
+    produced: two legs report back, a third id was dispatched and NEVER
+    produced a <testsuite> anywhere — no pass, no fail, no error entry,
+    because whatever runner owned it exited before creating one."""
+    with tempfile.TemporaryDirectory() as tmp:
+        hub_path = os.path.join(tmp, "hub.xml")
+        ws_path = os.path.join(tmp, "ws.xml")
+        out_path = os.path.join(tmp, "merged.xml")
+        # Dispatched: {1, 2, 3, 4}. Hub leg reports 1, 2. Websocket leg
+        # reports only 3 — 4 was dispatched to it and never came back.
+        _write_junit(hub_path, [1, 2])
+        _write_junit(ws_path, [3])
+        seen_ids = hybrid.merge_junit([hub_path, ws_path], out_path, total_elapsed=1.0)
+
+        check("merge_junit reports every id that DID come back",
+              seen_ids == {1, 2, 3})
+
+        all_ids = {1, 2, 3, 4}
+        missing_ids = sorted(all_ids - seen_ids)
+        check("the completeness diff catches the dropped id (4), and only it",
+              missing_ids == [4])
+
+        hub_ids, ws_ids = {1, 2}, {3, 4}
+        missing_ws = sorted(ws_ids & set(missing_ids))
+        check("the missing id is correctly attributed to the leg that lost it (websocket)",
+              missing_ws == [4])
+
+        check("nothing is reported missing when every dispatched id came back",
+              sorted({1, 2, 3} - hybrid.merge_junit([hub_path, ws_path],
+                                                      os.path.join(tmp, "merged2.xml"),
+                                                      total_elapsed=1.0)) == [])
+
+        # The bug this closes: the OLD completeness signal was "merged total
+        # != 0" — true here even though id 4 never ran anything at all.
+        merged_root = ET.parse(out_path).getroot()
+        old_signal_would_have_passed = int(merged_root.get("tests", "0")) != 0
+        check("the old signal ('total != 0') would have missed this — proving "
+              "the new check adds real coverage, not a no-op",
+              old_signal_would_have_passed and missing_ids == [4])
+
+
 def main() -> int:
     failures = []
 
@@ -117,6 +200,10 @@ def main() -> int:
     r.error = "timed out after 600s"
     check("a timeout is NOT retried (a hang can be a real deadlock)",
           not altool.is_infrastructure_error(r))
+
+    print("")
+    print("run-tests-hybrid.py completeness check:")
+    check_hybrid_completeness(check)
 
     if failures:
         print(f"\n{len(failures)} check(s) failed: {failures}")

--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -40,6 +40,7 @@ var numCodeunitsOverride = 0; // explicit codeunit count for progress display
 var verbose = false;
 var junitOutput = ""; // path to write JUnit XML — empty = don't emit
 var authProbe = false; // authenticate through OpenConnection only; never open a company or run AL tests
+var selfTestExitCode = false; // run ComputeExitCode's own assertions; no BC connection needed
 const int AuthenticationRejectedExitCode = 2;
 
 for (int i = 0; i < args.Length; i++)
@@ -59,6 +60,7 @@ for (int i = 0; i < args.Length; i++)
     else if (args[i] == "--verbose" || args[i] == "-v") verbose = true;
     else if (args[i] == "--junit-output" && i + 1 < args.Length) junitOutput = args[++i];
     else if (args[i] == "--auth-probe") authProbe = true;
+    else if (args[i] == "--self-test-exit-code") selfTestExitCode = true;
     else if (!args[i].StartsWith("--")) host = args[i];
 }
 
@@ -79,9 +81,66 @@ var recordedResults = new List<RecordedResult>();
 void Log(string msg) { if (verbose) Console.Error.WriteLine(msg); }
 
 int exitCode = 1;
-try { exitCode = authProbe ? await RunAuthenticationProbe() : await RunTests(); }
+try { exitCode = selfTestExitCode ? SelfTestExitCode() : authProbe ? await RunAuthenticationProbe() : await RunTests(); }
 catch (Exception ex) { Console.Error.WriteLine($"FATAL: {ex.Message}"); }
 return exitCode;
+
+// ComputeExitCode is the ENTIRE contract between "did the run actually finish"
+// and the process exit code — see #57. Drive it directly rather than only
+// tracing it by eye: `dotnet run --project tools/TestRunner -- --self-test-exit-code`
+// needs no BC connection and exits non-zero if any case below disagrees with
+// the real function.
+static int ComputeExitCode(bool runCompleted, int codeunitsRun, int numCodeunits, int liveFailed, int livePassed)
+{
+    if (!runCompleted)
+    {
+        // liveFailed can be 0 here — that used to mean "return 0". An abandoned
+        // run must never look like a clean pass: the codeunits that never ran
+        // recorded neither a pass nor a fail, and "0 failed" said nothing about
+        // them either way.
+        Console.WriteLine($"ERROR: run did not complete — only {codeunitsRun} of {numCodeunits} codeunit(s) executed");
+        return 1;
+    }
+    return liveFailed > 0 ? 1 : (livePassed > 0 ? 0 : 1);
+}
+
+int SelfTestExitCode()
+{
+    var failures = new List<string>();
+    void Check(string label, bool cond)
+    {
+        Console.WriteLine((cond ? "  PASS  " : "  FAIL  ") + label);
+        if (!cond) failures.Add(label);
+    }
+
+    Console.WriteLine("ComputeExitCode:");
+
+    // The bug this closes: an abandoned run (runCompleted=false) with 0 live
+    // failures used to fall through to `livePassed > 0 ? 0 : 1` and return 0 —
+    // a leg reporting green with codeunits that never ran at all.
+    Check("abandoned run, 0 failed, some passed -> FAILS (was: 0)",
+          ComputeExitCode(runCompleted: false, codeunitsRun: 12, numCodeunits: 24, liveFailed: 0, livePassed: 40) == 1);
+    Check("abandoned run, 0 failed, 0 passed (died before anything ran) -> FAILS",
+          ComputeExitCode(runCompleted: false, codeunitsRun: 0, numCodeunits: 24, liveFailed: 0, livePassed: 0) == 1);
+    Check("abandoned run, some failed anyway -> still FAILS",
+          ComputeExitCode(runCompleted: false, codeunitsRun: 12, numCodeunits: 24, liveFailed: 1, livePassed: 30) == 1);
+
+    // Completed runs keep their original semantics — this must NOT regress.
+    Check("completed run, 0 failed, some passed -> PASSES",
+          ComputeExitCode(runCompleted: true, codeunitsRun: 24, numCodeunits: 24, liveFailed: 0, livePassed: 40) == 0);
+    Check("completed run, some failed -> FAILS",
+          ComputeExitCode(runCompleted: true, codeunitsRun: 24, numCodeunits: 24, liveFailed: 1, livePassed: 39) == 1);
+    Check("completed run, 0 total (nothing to run) -> FAILS",
+          ComputeExitCode(runCompleted: true, codeunitsRun: 0, numCodeunits: 0, liveFailed: 0, livePassed: 0) == 1);
+
+    if (failures.Count > 0)
+    {
+        Console.WriteLine($"\n{failures.Count} check(s) failed: {string.Join(", ", failures)}");
+        return 1;
+    }
+    Console.WriteLine("\nall checks passed");
+    return 0;
+}
 
 async Task<int> RunAuthenticationProbe()
 {
@@ -194,6 +253,15 @@ async Task<int> RunTests()
     Log($"Running tests via WebSocket ({numCodeunits} codeunits, max {effectiveMaxIterations} iterations)...");
     int codeunitsRun = 0;
     printedCodeunits.Clear();
+    // Set true only when the loop breaks because BC confirmed there is no more
+    // work (allDone) or because we reached the codeunit count we were told to
+    // expect. Every other way out of this loop — a failed reconnect, a failed
+    // page-open, or running out of iterations — means the run was ABANDONED,
+    // not completed, and codeunitsRun < numCodeunits proves it: the caller
+    // (run-tests.sh) always passes --num-codeunits as the exact count it
+    // populated the suite with, so falling short of it here is never a
+    // legitimate outcome, only an unfinished one.
+    bool runCompleted = false;
     for (int iteration = 0; iteration < effectiveMaxIterations; iteration++)
     {
         // Proactive reconnect before each RunNextTest.
@@ -254,12 +322,21 @@ async Task<int> RunTests()
 
         if (allDone || codeunitsRun >= numCodeunits)
         {
+            runCompleted = true;
             if (allDone) Log("All tests executed (page confirmed)");
             else Log($"All {numCodeunits} codeunits executed — stopping");
             break;
         }
 
         await Task.Delay(500, CancellationToken.None);
+    }
+
+    if (!runCompleted)
+    {
+        Log($"WARN: run ended without completing — {codeunitsRun}/{numCodeunits} codeunit(s) executed. " +
+            "Stopped due to a reconnect/page-open failure or the iteration cap, not because BC " +
+            "reported the suite done. This is a session-establishment failure, not a test result — " +
+            "see https://github.com/StefanMaron/MsDyn365Bc.On.Linux/issues/57.");
     }
 
     // Print summary from live counts — no final OData read needed (saves ~3.5 minutes)
@@ -285,7 +362,7 @@ async Task<int> RunTests()
 
     Console.WriteLine($"\n=== Results ({elapsed.TotalSeconds:F0}s) ===");
     Console.WriteLine($"{total} total, {livePassed} passed, {liveFailed} failed, {liveSkipped} skipped");
-    return liveFailed > 0 ? 1 : (livePassed > 0 ? 0 : 1);
+    return ComputeExitCode(runCompleted, codeunitsRun, numCodeunits, liveFailed, livePassed);
 }
 
 async Task PrintLiveResults(byte[] authBytes, int codeunitsRun, int numCodeunits, DateTime startTime)


### PR DESCRIPTION
Re-opens #58 against `master`. **The content is unchanged from #58, which was already reviewed and approved** — `git diff 295302f..c31b0ae` is empty, byte for byte. This is restoring a decision that was already made, not asking for a new one.

## Why this PR exists: #58 merged, but not into `master`

#58's base was `agent/impl-7/testrunner-hub-flake` — #55's branch — because it extends `scripts/test-infrastructure-retry.py`, a file #55 introduced and which did not exist on `master` at the time.

What then happened, in order:

1. **13:05:27** — #55 was **squash**-merged to `master` as `a012cae3`. The squash is a new commit; #55's original branch was not fast-forwarded into `master`.
2. **13:06:12** — #58 merged **into that still-unsquashed branch**, 45 seconds later, before GitHub retargeted it to `master`.

So the branch received both commits and `master` received only #55's squash. `gh api repos/StefanMaron/MsDyn365Bc.On.Linux/compare/master...f9786352` reports **diverged, ahead 2 / behind 1**, with all six files still listed — the changes exist in git, on a branch nothing consumes.

A PR whose base is another PR's branch merges into that branch, and GitHub's retarget is not instantaneous. That is the whole mechanism.

## What is and is not deployed right now

This matters for anyone reading a CI log from this window and wondering which fixes were in play.

| change | PR | on `master`? | reaches CI how |
|---|---|---|---|
| `EnableDetailedErrors` in `entrypoint.sh` | #55 | **yes** (`a012cae3`) | container image, rebuilt 13:05:30–13:06:06 |
| gated single retry in `run-tests-altool.py` | #55 | **yes** | `scripts/` checked out from `master` per run — live from 13:05:27, no image needed |
| full container log as a failure artifact | #55 | **yes** | reusable workflow, live from 13:05:27 |
| **completeness check** in `run-tests-hybrid.py` | #58 | **no** | this PR |
| **`runCompleted` exit-code fix** in `tools/TestRunner/Program.cs` | #58 | **no** | this PR, **and then an image rebuild** — `tools/TestRunner/TestRunner.dll` is bundled in the image and `tools/**` is *not* in `build-image.yml`'s trigger paths, so merging this alone will not deploy it |

That last row is worth acting on separately: `build-image.yml` triggers on `src/**`, `scripts/**` and `extensions/**`. This PR touches `scripts/run-tests-hybrid.py`, so a build will fire — but only incidentally. A PR that touched `tools/TestRunner/` alone would merge and silently not deploy.

**The exposed window:** every corpus run between 2026-09-05 13:05 and this PR merging has the retry and the detailed errors, and does **not** have the completeness check or the exit-code fix. A leg in that window could still have gone green with codeunits missing.

## What the content does (unchanged from #58)

Two halves of one defect — a leg reporting clean when it did not run everything it claims to have run.

**`tools/TestRunner/Program.cs`** — the websocket runner's loop breaks out on a failed reconnect, a failed page-open, or the iteration cap without setting any failure flag, and then `return liveFailed > 0 ? 1 : (livePassed > 0 ? 0 : 1)` returns **0** for a run abandoned halfway with no failures recorded. A `runCompleted` flag now gates the exit code through an extracted `ComputeExitCode`, exercised by `--self-test-exit-code` with no BC connection needed.

**`scripts/run-tests-hybrid.py`** — the only completeness signal was "the merged JUnit total is non-zero". `merge_junit` now returns the set of codeunit ids that produced a `<testsuite>`; `main()` diffs it against the ids it dispatched, attributes any gap to the leg that lost it, and fails the run.

**Not observed producing a false green.** Reachable from the code. Corpus PR #146 aborted at codeunit 0 of its websocket leg, so that leg contributed 0 tests and the run still exited non-zero; the same abort after even one codeunit had passed would have read "N passed, 0 failed" with the rest missing.

## Verification, re-run on this rebase

Both self-tests pass against `master` + this commit:

```
$ python3 scripts/test-infrastructure-retry.py          # 13/13, all checks passed
$ dotnet tools/TestRunner/bin/Debug/net8.0/TestRunner.dll --self-test-exit-code   # 6/6, all checks passed
```

RED→GREEN was established on #58 and is unchanged: patching `merge_junit` back to returning `None` makes the first completeness assertion raise; reverting `ComputeExitCode` to the original one-liner fails exactly the "abandoned run, 0 failed, some passed" case and no other.

---
Written by Claude Code agent impl-7.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
