### PR TITLE
fix: run the hybrid runner's two legs one after the other, not at once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,8 +680,19 @@ cannot recover attribute usage from a compiled `.app` — checked empirically,
 `scripts/run-tests-hybrid.py` is the orchestrator: discovers the full test
 codeunit set from the `.app` (same `SymbolReference.json` discovery
 `run-tests-altool.py` already does), classifies via the AL source dir,
-runs both legs **concurrently** (different BC endpoints, no shared-resource
-conflict), and merges JUnit + summary counts into one report. Codeunits
+runs the two legs **one after the other, altool first**, and merges JUnit +
+summary counts into one report. They used to run concurrently, justified as
+"different BC endpoints, no shared-resource conflict" — the endpoints do
+differ, but the legs share one service tier, tenant, company and set of
+application metadata, and a client session holding a page open dies with
+"The page definition has changed while opening the page" when the metadata
+generation moves under it. Five instances in the 18 most recent failed runs
+of the corpus that consumes this workflow, all on 28.x legs (where the
+second leg exists) and none on 27.x. See `run_legs` in the script for the
+full evidence, and StefanMaron/BusinessCentral.AL.Language.Tests#158.
+Altool goes first because the websocket leg republishes the app, which is
+the only metadata-mutating action either leg performs; last is where it does
+the least harm. Codeunits
 with no matching AL source are conservatively routed to websocket —
 unproven safety is treated as unsafe.
 

--- a/KNOWN-LIMITATIONS.md
+++ b/KNOWN-LIMITATIONS.md
@@ -315,9 +315,14 @@ gives that session an NRE.
 
 bc-linux does not cause the race but is unusually good at provoking it:
 `run-tests-altool.py`'s default `cli` transport starts a fresh BC session per
-codeunit, and `run-tests-hybrid.py` runs a websocket leg concurrently, so
-session start and database teardown overlap continuously for the length of a
-run. One bad landing in a 300-codeunit run reddens the leg.
+codeunit, so session start and database teardown overlap continuously for the
+length of a run. One bad landing in a 300-codeunit run reddens the leg.
+
+`run-tests-hybrid.py` used to add a second, concurrent websocket leg on top of
+that; it no longer does — the legs are serialised (see `run_legs` there, and
+StefanMaron/BusinessCentral.AL.Language.Tests#158). That removes one source of
+overlap, not the race: the per-codeunit session churn inside the altool leg is
+by itself enough to provoke it, so Patches #32 and #32b below stay load-bearing.
 
 **Patch #32** no-ops `NavLicense.Dispose(bool)` and **Patch #32b** no-ops
 `NavDatabaseSecurityAndLicense.Dispose(bool)`. Both bodies are teardown

--- a/scripts/run-tests-hybrid.py
+++ b/scripts/run-tests-hybrid.py
@@ -20,10 +20,15 @@ the websocket runner (unproven safety == unsafe) and this script behaves
 like a slower version of run-tests.sh — pass --al-source-dir to get the
 speedup.
 
-Both underlying runners are invoked concurrently (they hit different BC
-endpoints — the dev-endpoint hub vs the client-session websocket — so
-there's no shared-resource conflict), each restricted to its own codeunit
-subset via --codeunit-range with an explicit id list.
+The two runners are invoked ONE AFTER THE OTHER, altool first, each
+restricted to its own codeunit subset via --codeunit-range with an explicit
+id list. They used to run concurrently on two threads, justified as "they
+hit different BC endpoints, so there's no shared-resource conflict". The
+endpoints do differ; what they share is the whole of the rest of it — one
+service tier, one tenant, one company, and one set of APPLICATION METADATA.
+That last one is the resource that was in conflict, and it produced a real
+flake: see StefanMaron/BusinessCentral.AL.Language.Tests#158 and the
+comment on run_legs below for the evidence.
 
 The altool leg defaults to --altool-transport cli, NOT hub/auto, even
 though hub is ~40x faster per codeunit. Per
@@ -68,7 +73,6 @@ import os
 import re
 import subprocess
 import sys
-import threading
 import time
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -153,6 +157,56 @@ def _run_websocket(args, codeunit_ids: list[int], junit_path: str) -> _RunnerRes
     r.stdout = proc.stdout or ""
     r.junit_path = junit_path if os.path.isfile(junit_path) else None
     return r
+
+
+def run_legs(args, hub_ids: list[int], ws_ids: list[int],
+             hub_junit: str, ws_junit: str) -> dict[str, _RunnerResult]:
+    """Run both legs SEQUENTIALLY, altool first, and return their results.
+
+    WHY NOT CONCURRENTLY (StefanMaron/BusinessCentral.AL.Language.Tests#158)
+      These two legs used to run on two threads at once. The justification was
+      that they hit different BC endpoints — the dev-endpoint hub versus the
+      client-session websocket — and therefore could not conflict. They do hit
+      different endpoints. They also share one service tier, one tenant, one
+      company and one set of application metadata, and that last one is what
+      broke: a client session that has a page open is invalidated when the
+      metadata generation moves under it, and BC says so with
+
+        The page definition has changed while opening the page, please try to
+        re-open the page. Page ID: <n>
+
+      Measured over the 18 most recent failed runs of the corpus that consumes
+      this workflow: five instances, every one on a 28.x leg and none on 27.0,
+      27.3 or 27.5 — which is the signature, because `test_runner: auto` falls
+      back to the single websocket runner below BC 28 and there is no second
+      leg there to race. Always codeunit 60933, and a DIFFERENT test inside it
+      each time, because the websocket leg's codeunit order is not
+      deterministic. Position predicted the outcome: five failures with 60933
+      at position 2 or 3 of the leg, and the one observation of it running at
+      position 12 passed. The websocket leg takes 25-29 s against the altool
+      leg's 208-271 s, so it fits entirely inside the altool leg's opening
+      phase — no part of it ever ran alone.
+
+      What is NOT established: the BC event-log capture is tail-truncated
+      across the failure window, so there is no server-side trace of a
+      metadata generation actually changing. Serialising is justified by that
+      correlation plus the mechanism, not by a proven server-side record.
+
+    WHY ALTOOL FIRST, and not the other order
+      The websocket leg republishes the app (`bc_publish_app` in
+      run-tests.sh, SchemaUpdateMode=forcesync) before it runs anything. That
+      is the one metadata-mutating action in either leg. Running it last means
+      it happens when nothing else holds a session, instead of at the moment
+      the other leg is opening its first ones.
+
+    Cost: the websocket leg's wall time is no longer hidden inside the altool
+    leg's. On the corpus that is 25-29 s added to a 208-271 s leg, per BC
+    version, across an eight-version matrix on a shared Actions queue.
+    """
+    results: dict[str, _RunnerResult] = {}
+    results["altool"] = _run_altool(args, hub_ids, hub_junit)
+    results["websocket"] = _run_websocket(args, ws_ids, ws_junit)
+    return results
 
 
 # One <testsuite> per codeunit that ever got a CodeunitRun/RecordedResult,
@@ -271,19 +325,7 @@ def main() -> int:
     hub_junit = f"{args.junit_output}.hub.xml" if args.junit_output else "/tmp/run-tests-hybrid-hub-junit.xml"
     ws_junit = f"{args.junit_output}.ws.xml" if args.junit_output else "/tmp/run-tests-hybrid-ws-junit.xml"
 
-    results: dict[str, _RunnerResult] = {}
-
-    def go_altool():
-        results["altool"] = _run_altool(args, hub_ids, hub_junit)
-
-    def go_websocket():
-        results["websocket"] = _run_websocket(args, ws_ids, ws_junit)
-
-    threads = [threading.Thread(target=go_altool), threading.Thread(target=go_websocket)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    results = run_legs(args, hub_ids, ws_ids, hub_junit, ws_junit)
     total_elapsed = time.monotonic() - overall_start
 
     for name in ("altool", "websocket"):

--- a/scripts/test-infrastructure-retry.py
+++ b/scripts/test-infrastructure-retry.py
@@ -37,6 +37,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 import xml.etree.ElementTree as ET
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -163,6 +164,93 @@ def check_hybrid_completeness(check) -> None:
               old_signal_would_have_passed and missing_ids == [4])
 
 
+def check_hybrid_legs_are_serialised(check) -> None:
+    """The two legs must not overlap, and altool must go first
+    (StefanMaron/BusinessCentral.AL.Language.Tests#158).
+
+    They used to run on two threads at once, on the reasoning that different BC
+    endpoints cannot conflict. They share one service tier, tenant, company and
+    set of application metadata; a client session holding a page open dies with
+    "The page definition has changed while opening the page" when the metadata
+    generation moves under it. Five instances in the 18 most recent failed
+    corpus runs, all on 28.x — where the second leg exists — and none on 27.x,
+    where `test_runner: auto` runs the websocket runner alone.
+
+    Asserted on observed START and END times of the real run_legs, with the two
+    leg functions replaced by fakes. Under the previous threaded implementation
+    the websocket leg starts before the altool leg ends, so this fails; there is
+    no arrangement of a correct sequential implementation that fails it.
+
+    Order matters as much as non-overlap: the websocket leg is the one that
+    republishes the app, which is the only metadata-mutating action either leg
+    performs. Running it last means nothing else holds a session when it fires.
+    """
+    calls: list[tuple[str, float, float]] = []
+
+    def fake(name):
+        def run(args, ids, junit_path):
+            start = time.monotonic()
+            time.sleep(0.05)          # long enough that an overlap is measurable
+            calls.append((name, start, time.monotonic()))
+            r = hybrid._RunnerResult(name)
+            r.invoked = bool(ids)
+            return r
+        return run
+
+    real_altool, real_ws = hybrid._run_altool, hybrid._run_websocket
+    try:
+        hybrid._run_altool = fake("altool")
+        hybrid._run_websocket = fake("websocket")
+        results = hybrid.run_legs(object(), [1, 2], [3, 4], "/dev/null", "/dev/null")
+    finally:
+        hybrid._run_altool, hybrid._run_websocket = real_altool, real_ws
+
+    check("both legs ran", sorted(n for n, _, _ in calls) == ["altool", "websocket"])
+    check("run_legs returns a result for each leg",
+          sorted(results.keys()) == ["altool", "websocket"])
+
+    if len(calls) == 2:
+        by_name = {n: (s, e) for n, s, e in calls}
+        altool_start, altool_end = by_name["altool"]
+        ws_start, ws_end = by_name["websocket"]
+        check("the altool leg runs FIRST (the websocket leg republishes, so it goes last)",
+              altool_start < ws_start)
+        check("the legs DO NOT OVERLAP — the websocket leg starts only after altool ends",
+              ws_start >= altool_end)
+        # The negative that makes the above mean something: under the threaded
+        # implementation both legs start within microseconds of each other, so
+        # ws_start < altool_end by ~the whole sleep. A test that only checked
+        # ordering would have passed on the broken version roughly half the time.
+        check("the observed gap is a real serialisation, not a scheduling accident",
+              ws_start - altool_start >= 0.05)
+
+
+def check_hybrid_leg_order_survives_an_empty_leg(check) -> None:
+    """Negative: routing every codeunit to one leg is normal (no --al-source-dir
+    sends everything to websocket), and must still produce both result entries
+    rather than a KeyError in the caller's `for name in ("altool", "websocket")`
+    loop."""
+    def fake(name):
+        def run(args, ids, junit_path):
+            r = hybrid._RunnerResult(name)
+            r.invoked = bool(ids)
+            return r
+        return run
+
+    real_altool, real_ws = hybrid._run_altool, hybrid._run_websocket
+    try:
+        hybrid._run_altool = fake("altool")
+        hybrid._run_websocket = fake("websocket")
+        results = hybrid.run_legs(object(), [], [3, 4], "/dev/null", "/dev/null")
+    finally:
+        hybrid._run_altool, hybrid._run_websocket = real_altool, real_ws
+
+    check("an empty altool leg still yields both result entries",
+          sorted(results.keys()) == ["altool", "websocket"])
+    check("the empty leg is marked not-invoked and the populated one is",
+          results["altool"].invoked is False and results["websocket"].invoked is True)
+
+
 def main() -> int:
     failures = []
 
@@ -204,6 +292,11 @@ def main() -> int:
     print("")
     print("run-tests-hybrid.py completeness check:")
     check_hybrid_completeness(check)
+
+    print("")
+    print("run-tests-hybrid.py leg serialisation:")
+    check_hybrid_legs_are_serialised(check)
+    check_hybrid_leg_order_survives_an_empty_leg(check)
 
     if failures:
         print(f"\n{len(failures)} check(s) failed: {failures}")


### PR DESCRIPTION
Opened by agent impl-8, with the repository owner's approval for this PR.

`run-tests-hybrid.py` started its two legs on two threads and joined them at the end. Its docstring justified that:

> Both underlying runners are invoked concurrently (they hit different BC endpoints — the dev-endpoint hub vs the client-session websocket — **so there's no shared-resource conflict**)

The endpoints do differ. The legs also share one service tier, one tenant, one company and one set of **application metadata**, and that last one is the resource actually in conflict. A client session holding a page open dies when the metadata generation moves under it, and BC says so:

```
The page definition has changed while opening the page, please try to re-open the page. Page ID: <n>
```

This PR runs the legs one after the other, altool first. The docstring changes with the code — that sentence is what made the concurrency look deliberate and safe to a future reader, so leaving it in place while changing the behaviour would have been worse than leaving both alone.

## The evidence

Measured over the **18 most recent failed runs** of `StefanMaron/BusinessCentral.AL.Language.Tests`, which consumes `bc-test-from-source.yml`. Five instances:

| run | leg | test | codeunit 60933's position in the websocket leg | outcome |
|---|---|---|---|---|
| 33968655888 | 28.1 | `Report_Run_CancelledRequestPageRunsNothingAndRaisesNoError` | 3 / 24 | FAIL |
| 33967089134 | 28.2 | `Report_Run_OpensTheRequestPageAndRunsTheBodyWhenTheHandlerConfirms` | 3 / 24 | FAIL |
| 33966180322 | 28.1 | `Report_Run_OpensTheRequestPageAndRunsTheBodyWhenTheHandlerConfirms` | 3 / 24 | FAIL |
| 33817995143 | 28.3 | `Report_Run_NonProcessingOnlyRequestPageHasNoOKAction` | 2 / 23 | FAIL |
| 33817995143 | 28.2 | — | **12 / 23** | **PASS** (that leg failed for an unrelated reason) |

Four things that together point at one cause:

1. **Every instance is on a 28.x leg; none on 27.0, 27.3 or 27.5.** That is the signature of the second leg, because `test_runner: auto` falls back to the single websocket runner below BC 28 — there is nothing there to race.
2. **Always codeunit 60933, a different test inside it each time** (three names so far). The websocket leg's codeunit order is not deterministic, so what varies is which of its tests is executing, not which codeunit is affected. That is why this looked like several unrelated flakes.
3. **Position predicted the outcome** — five failures with 60933 at position 2 or 3 of the leg, and the one observation of it at position 12 passed.
4. **The websocket leg never ran alone.** 25-29 s against the altool leg's 208-271 s, both started together, so the whole of it sits inside the altool leg's opening phase.

Report *request* pages have no stored page metadata — BC derives them from the report object on first open — which is consistent with them being the object type that shows this and ordinary pages not.

**What is not established, and I would rather say so than imply otherwise:** the BC event-log capture in these runs is tail-truncated across the failure window (it covers 13:30:18-13:31:46 and 13:35:34-36, and the failure was around 13:35:1x), so there is **no server-side trace of a metadata generation actually changing**. Serialising is justified by the correlation above plus the mechanism, not by a proven server-side record.

Full write-up and the raw scan: StefanMaron/BusinessCentral.AL.Language.Tests#158.

## Why altool first

The websocket leg republishes the app (`bc_publish_app` in `run-tests.sh`, `SchemaUpdateMode=forcesync`) before it runs anything. That is the only metadata-mutating action either leg performs. Running it last means it fires when nothing else holds a session, instead of at the moment the other leg opens its first ones. Ordering is asserted by a test, not left to the reading.

## Cost

The websocket leg's wall time is no longer hidden inside the altool leg's. On the corpus that is **25-29 s added to a 208-271 s leg**, per BC version, across an eight-version matrix — and GitHub Actions concurrency is per account, so those seconds sit in front of other repositories' runs too. I am stating the seconds rather than a percentage because the ratio moves with how many codeunits get routed to each leg.

## Tests

Added to `scripts/test-infrastructure-retry.py`, the existing self-test for this machinery, in its `check(label, cond)` idiom. To make the claim testable I extracted the leg-running into `run_legs(...)`; the test replaces the two leg functions with fakes and asserts on observed start/end times of the real `run_legs`.

- **RED**, with the threaded implementation restored and the tests unchanged: 2 of the new checks fail — *"the legs DO NOT OVERLAP"* and *"the observed gap is a real serialisation, not a scheduling accident"*.
- **GREEN**: all checks pass.

The RED run is worth one note. *"the altool leg runs FIRST"* **passed on the broken threaded version** — both threads start within microseconds and altool happens to be started first — so an ordering-only assertion would have been satisfied by the bug. That is why the non-overlap check and the minimum-gap check are both there; the comment in the test says so.

There is also a negative for the ordinary case where `--al-source-dir` is absent and every codeunit goes to one leg: both result entries must still exist, or `main`'s `for name in ("altool", "websocket")` loop raises.

**One thing I could not verify:** I found no CI workflow in this repository that runs `scripts/test-infrastructure-retry.py`, so as far as I can tell it is run by hand. I have not wired it in — that is a bigger change to your repository than this fix and it is your call — but a self-test nothing runs is worth knowing about.

## Two things I deliberately did not change

- **`publish-app.sh` treating a 422 "duplicate package ID" as success.** I flagged this to my coordinator as a possible silent-success defect and I was wrong: reading `publish-app.sh`, the benign-422 matching is deliberate, narrowly scoped to BC's known benign phrasings, and its header records exactly why the two looser earlier versions were wrong. Nothing to fix. The only residue is cosmetic — `Publishing al-language.app... OK` reads as "published" when nothing was published because it was already there — and that is not worth a change in someone else's repository.
- **Making the previous behaviour available behind a flag.** A flag whose fast setting is the shape this PR removes is a trap. The threaded version is a few lines away in this PR's history if you want to measure it.

## Docs updated with the behaviour

- `CLAUDE.md` — the "runs both legs concurrently (different BC endpoints, no shared-resource conflict)" paragraph.
- `KNOWN-LIMITATIONS.md` — the `NavLicense.Dispose` section cites the concurrent websocket leg as one of two things that provoke that race. I corrected it **without** claiming the race is gone: the altool `cli` transport still starts a fresh session per codeunit, so session-start/teardown overlap continues by itself and Patches #32 / #32b stay load-bearing.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
