### PR TITLE
fix(test-runner): batch codeunit ids so a growing corpus stops overflowing BC's 2048-char CodeunitIds field

### DIFF
--- a/.github/workflows/check-example-drift.yml
+++ b/.github/workflows/check-example-drift.yml
@@ -42,6 +42,21 @@ jobs:
       - name: Check examples against the reusable workflows
         run: python3 scripts/check-example-drift.py
 
+      # run-tests.sh batches its codeunit list across several suite-setup
+      # requests once the joined ids pass BC's 2048-character CodeunitIds
+      # field. A batch lost in that loop does not look like an error — it
+      # looks like a green run with fewer tests in it, which is the shape
+      # issue #57 was about. These three run in seconds, need no BC, and are
+      # the only thing standing between that bug and a merge.
+      - name: Codeunit id batching is total
+        run: python3 scripts/chunk-codeunit-ids.py --self-test
+
+      - name: Batched JUnit reports merge without loss
+        run: python3 scripts/merge-junit-batches.py --self-test
+
+      - name: run-tests.sh runs every batch (end to end, fake BC)
+        run: python3 scripts/test-run-tests-batching.py
+
       # ci-lock.sh runs on every pipeline in the repo and in every consumer
       # that copied an example, and nothing else lints it — the only other
       # shellcheck pass in CI is snapshot-scoped (test-snapshot.yml). A bug

--- a/README.md
+++ b/README.md
@@ -253,6 +253,17 @@ When `--app` is provided the script reads `SymbolReference.json` from the
 `--codeunit-range` if also provided. This avoids the SetupSuite call having
 to iterate tens of thousands of nonexistent IDs.
 
+**Long codeunit lists are batched automatically.** The websocket runner sets
+the suite up by POSTing the ids as one string field, `CodeunitIds:
+Text[2048]` on table 99903, so a list past 2048 characters is rejected by BC
+outright — HTTP 400 `Application_StringExceededLength`, before any test runs.
+Roughly 340 five-digit ids is where that lands. `run-tests.sh` splits the
+list, sets the suite up and runs it once per batch, and merges the reports,
+so the JUnit XML and the `N total, P passed, F failed` line are the same as
+an un-batched run's. Set `BC_CODEUNIT_IDS_MAX_CHARS` to change the per-batch
+budget (default 1000). `python3 scripts/test-run-tests-batching.py` exercises
+the whole loop against a fake BC — no container needed.
+
 **Which company tests run in:** by default both runners read the OData
 `Company` page and pick the evaluation (demo) company. That works on any
 localization without knowing the name in advance — the CRONUS company is
@@ -348,6 +359,7 @@ BC_DEV_PORT=17049 docker compose up -d
 | `BC_SQL_IMAGE`    | GHCR mirror      | SQL Server image. See "SQL Server image" below.                              |
 | `BC_DL_STREAMS`   | `16`             | Parallel byte-range streams per artifact zip (32 total across the two).       |
 | `BC_DL_BIG_SHARE` | `70`             | Percent of the stream budget given to the larger zip so it lands first and its extraction overlaps the other download. `50` restores an even split. |
+| `BC_CODEUNIT_IDS_MAX_CHARS` | `1000` | Characters of codeunit ids `run-tests.sh` sends per suite-setup request. BC's `CodeunitIds` field is `Text[2048]`; the default leaves room for the test suite to grow. |
 
 **SQL Server image:** the `sql` service defaults to
 `ghcr.io/stefanmaron/msdyn365bc.on.linux/mssql:2022-zstd`, a mirror of

--- a/scripts/chunk-codeunit-ids.py
+++ b/scripts/chunk-codeunit-ids.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Split a comma-separated codeunit id list into chunks the Test Runner
+Extension's API can actually accept.
+
+WHY THIS EXISTS
+---------------
+run-tests.sh sets the websocket runner's test suite up by POSTing the whole
+codeunit id list to
+
+    /api/custom/automation/v1.0/companies(<id>)/codeunitRunRequests
+
+as one JSON string field. That field is `CodeunitIds: Text[2048]` on table
+99903 (extensions/TestRunnerExtension/src/RunnerTable.al), so BC rejects the
+POST outright once the joined list passes 2048 characters:
+
+    HTTP 400 Application_StringExceededLength
+    "The length of the string is 2051, but it must be less than or equal to
+     2048 characters."
+
+Nothing about that is a test failure — publishing and discovery both succeed,
+and the run dies before a single test executes. It is a pure size ceiling, and
+a growing test suite walks into it silently: a repository is fine at 2047
+characters and red at 2049. StefanMaron/BusinessCentral.AL.Language.Tests hit
+it on 2026-09-05: 342 test codeunits joined to 2051 characters.
+
+The ceiling belongs to BC's field definition, so the fix is on this side:
+split the list, set the suite up and run it once per chunk, and merge the
+results. run-tests.sh does the running; this module does the splitting, and is
+kept separate so the split can be tested without a BC container.
+
+TOTALITY IS THE WHOLE POINT
+---------------------------
+A batching bug that drops a chunk does not look like a bug. It looks like a
+green run with fewer tests in it — the exact false-green shape issue #57 was
+about. So `split_ids` never returns without proving, on the values it is about
+to return, that:
+
+  * the chunks concatenate back to the input token list, in order, with
+    nothing dropped, duplicated or reordered;
+  * no chunk is empty;
+  * no chunk exceeds the character budget, unless it is a single token that
+    cannot be split any further (which is reported, not hidden).
+
+`--self-test` runs those checks against known-good and known-BROKEN chunkings,
+so the verifier is proven to reject the failure it exists to catch rather than
+just proven to accept correct input. It needs no BC connection:
+
+    python3 scripts/chunk-codeunit-ids.py --self-test
+
+USAGE
+-----
+    python3 scripts/chunk-codeunit-ids.py --max-chars 1000 "60100,60101,60102"
+    printf '%s' "$IDS" | python3 scripts/chunk-codeunit-ids.py --max-chars 1000
+
+Prints one chunk per line on stdout. Exit 0 on success, 2 on bad input or a
+failed internal check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+# BC's hard ceiling: the width of `CodeunitIds` on table 99903.
+FIELD_LIMIT = 2048
+
+# Default budget per request. Deliberately far below FIELD_LIMIT rather than
+# just under it: the list grows every time somebody adds a test codeunit, and
+# a fix that lands at 2047 characters is red again on the next merge. Halving
+# the ceiling means the list has to DOUBLE before the chunk count moves, and
+# an extra chunk costs one suite setup plus one runner connection — a few
+# seconds against a leg measured in minutes. Cheap insurance, so buy plenty.
+DEFAULT_MAX_CHARS = 1000
+
+
+class ChunkError(ValueError):
+    """Raised when the input cannot be split, or a self-check fails."""
+
+
+def parse_tokens(raw: str) -> list[str]:
+    """Split the raw list on commas, dropping empties and surrounding space.
+
+    Tokens are kept verbatim otherwise: SetupSuite accepts both bare ids
+    ("60100") and ranges ("60100-60120"), and this must not reinterpret
+    either — it only decides where the commas that separate requests go.
+    """
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def verify_chunks(tokens: list[str], chunks: list[str], max_chars: int) -> None:
+    """Raise ChunkError unless `chunks` is a faithful, bounded split of `tokens`.
+
+    Kept as a free function taking both sides so the self-test can feed it a
+    deliberately broken chunking and confirm it objects.
+    """
+    if not chunks:
+        raise ChunkError("split produced no chunks at all")
+
+    rebuilt: list[str] = []
+    for i, chunk in enumerate(chunks):
+        if not chunk:
+            raise ChunkError(f"chunk {i + 1} is empty")
+        if chunk != chunk.strip():
+            raise ChunkError(f"chunk {i + 1} has leading/trailing whitespace")
+        parts = chunk.split(",")
+        if any(p == "" for p in parts):
+            raise ChunkError(f"chunk {i + 1} contains an empty id: {chunk!r}")
+        if len(chunk) > max_chars and len(parts) > 1:
+            raise ChunkError(
+                f"chunk {i + 1} is {len(chunk)} chars, over the {max_chars}-char "
+                f"budget, and holds {len(parts)} ids so it could have been split"
+            )
+        rebuilt.extend(parts)
+
+    if rebuilt != tokens:
+        # Say WHICH way it diverged; "not equal" on two 341-element lists is
+        # not a diagnosis.
+        if len(rebuilt) != len(tokens):
+            raise ChunkError(
+                f"chunks carry {len(rebuilt)} id(s) but the input had "
+                f"{len(tokens)} — {abs(len(tokens) - len(rebuilt))} "
+                f"{'lost' if len(rebuilt) < len(tokens) else 'invented'}"
+            )
+        first = next(i for i, (a, b) in enumerate(zip(rebuilt, tokens)) if a != b)
+        raise ChunkError(
+            f"chunks reorder or alter the id list: position {first} is "
+            f"{rebuilt[first]!r}, input had {tokens[first]!r}"
+        )
+
+
+def split_ids(raw: str, max_chars: int = DEFAULT_MAX_CHARS) -> list[str]:
+    """Split `raw` into comma-joined chunks of at most `max_chars` characters.
+
+    Chunks are contiguous slices in input order, so the resulting execution
+    order is the same as an un-chunked run's.
+    """
+    if max_chars < 1:
+        raise ChunkError(f"max_chars must be positive, got {max_chars}")
+
+    tokens = parse_tokens(raw)
+    if not tokens:
+        raise ChunkError("no codeunit ids to split")
+
+    chunks: list[str] = []
+    current = ""
+    for token in tokens:
+        candidate = f"{current},{token}" if current else token
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = token
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+
+    # A single token wider than the whole budget cannot be split; it goes out
+    # on its own and is called out, because the caller's POST may still be
+    # rejected and a silent pass-through would hide why.
+    for chunk in chunks:
+        if len(chunk) > max_chars and "," not in chunk:
+            print(
+                f"WARN: codeunit id token {chunk!r} is {len(chunk)} chars, longer "
+                f"than the {max_chars}-char budget on its own — sending it alone",
+                file=sys.stderr,
+            )
+
+    verify_chunks(tokens, chunks, max_chars)
+    return chunks
+
+
+# --------------------------------------------------------------------------
+# Self-test — no BC connection, no network, runs in milliseconds.
+# --------------------------------------------------------------------------
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        print(("  PASS  " if cond else "  FAIL  ") + label)
+        if not cond:
+            failures.append(label)
+
+    def raises(fn) -> bool:
+        try:
+            fn()
+        except ChunkError:
+            return True
+        except Exception:  # noqa: BLE001 - any other error is still a failure
+            return False
+        return False
+
+    print("split_ids:")
+
+    # 342 five-digit ids join to 2051 characters — the exact list length that
+    # took the AL-language corpus red on 2026-09-05, three characters over.
+    ids = [str(60000 + i) for i in range(342)]
+    raw = ",".join(ids)
+    check("the real-world case is over BC's own field limit (this is the bug)",
+          len(raw) == 2051 and len(raw) > FIELD_LIMIT)
+
+    chunks = split_ids(raw, 1000)
+    check("342 ids at 1000 chars produce more than one chunk", len(chunks) > 1)
+    check("every chunk fits the budget", all(len(c) <= 1000 for c in chunks))
+    check("every chunk fits BC's field limit too",
+          all(len(c) <= FIELD_LIMIT for c in chunks))
+    check("chunks rejoin to exactly the input, in order",
+          ",".join(chunks).split(",") == ids)
+    check("no chunk is empty", all(c for c in chunks))
+
+    # Boundary: a budget that lands exactly on a separator, and one either side.
+    exact = split_ids("111,222,333", 11)   # "111,222,333" is 11 chars
+    check("a list exactly at the budget stays one chunk", exact == ["111,222,333"])
+    check("one char under the budget splits", split_ids("111,222,333", 10) ==
+          ["111,222", "333"])
+    check("a tiny budget degrades to one id per chunk",
+          split_ids("111,222,333", 3) == ["111", "222", "333"])
+
+    # Ranges are tokens like any other and must survive verbatim.
+    check("range tokens are preserved, not expanded",
+          split_ids("60100-60120,60200", 12) == ["60100-60120", "60200"])
+
+    # Whitespace and stray separators in, clean tokens out.
+    check("whitespace and empty fields are normalised away",
+          split_ids(" 111 , ,222,\n333 ", 1000) == ["111,222,333"])
+
+    check("empty input is an error, not an empty run",
+          raises(lambda: split_ids("", 1000)))
+    check("a comma-only input is an error too",
+          raises(lambda: split_ids(" , , ", 1000)))
+    check("a non-positive budget is an error",
+          raises(lambda: split_ids("111,222", 0)))
+
+    # An id longer than the budget cannot be split — it must still come out,
+    # exactly once, rather than being dropped to satisfy the bound.
+    over = split_ids("1234567890,7", 4)
+    check("an oversized single token is emitted rather than dropped",
+          ",".join(over).split(",") == ["1234567890", "7"])
+
+    print("\nverify_chunks rejects broken chunkings:")
+
+    good = ["111,222", "333"]
+    toks = ["111", "222", "333"]
+    check("the good chunking is accepted",
+          not raises(lambda: verify_chunks(toks, good, 10)))
+    # These are the mutations that would ship as a green run with fewer tests.
+    check("a DROPPED last chunk is rejected",
+          raises(lambda: verify_chunks(toks, ["111,222"], 10)))
+    check("a dropped id inside a chunk is rejected",
+          raises(lambda: verify_chunks(toks, ["111", "333"], 10)))
+    check("a DUPLICATED id is rejected",
+          raises(lambda: verify_chunks(toks, ["111,222", "222,333"], 10)))
+    check("REORDERED ids are rejected",
+          raises(lambda: verify_chunks(toks, ["222,111", "333"], 10)))
+    check("an empty chunk is rejected",
+          raises(lambda: verify_chunks(toks, ["111,222", "", "333"], 10)))
+    check("an over-budget splittable chunk is rejected",
+          raises(lambda: verify_chunks(toks, ["111,222,333"], 10)))
+    check("no chunks at all is rejected",
+          raises(lambda: verify_chunks(toks, [], 10)))
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed: {', '.join(failures)}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        description="Split a comma-separated codeunit id list into "
+                    "API-request-sized chunks.")
+    ap.add_argument("ids", nargs="?", default=None,
+                    help="comma-separated ids; read from stdin when omitted")
+    ap.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS,
+                    help=f"characters per chunk (default {DEFAULT_MAX_CHARS}; "
+                         f"BC's field limit is {FIELD_LIMIT})")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the built-in checks and exit; needs no BC")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    raw = args.ids if args.ids is not None else sys.stdin.read()
+    try:
+        for chunk in split_ids(raw, args.max_chars):
+            print(chunk)
+    except ChunkError as ex:
+        print(f"ERROR: {ex}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/merge-junit-batches.py
+++ b/scripts/merge-junit-batches.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Merge the per-batch JUnit reports of one websocket run into a single file,
+and prove nothing went missing on the way.
+
+WHY THIS EXISTS
+---------------
+run-tests.sh has to split its codeunit list across several suite-setup
+requests once the joined list passes BC's 2048-character `CodeunitIds` field
+(see scripts/chunk-codeunit-ids.py). Each batch is set up and executed on its
+own, so each produces its own JUnit XML and its own "N total, P passed"
+summary. Downstream must not be able to tell a batched run from a
+single-request one, so the batches are merged back into one report here.
+
+The merge is also where a batching bug would hide. A dropped batch does not
+look like an error: it looks like a green run with fewer tests in it — the
+false-green shape of issue #57. So this refuses to stay quiet about it:
+
+  * the merged `tests` count must equal the sum of the batches' own counts,
+    or the merge itself lost something;
+  * every dispatched codeunit must appear as a `<testsuite name="Codeunit N">`
+    in the result. In `--strict` mode (used when the list actually WAS split)
+    a codeunit reporting nothing at all fails the run.
+
+The per-batch files are disjoint by construction — chunk-codeunit-ids.py
+guarantees each codeunit id lands in exactly one batch — so merging is a
+concatenation of `<testsuite>` elements with the roll-up attributes
+recomputed. The output shape matches run-tests-hybrid.py's merge, which is
+what consumers (GitHub Checks reporters, Azure DevOps, AL-Go's AnalyzeTests)
+already read.
+
+Self-test, no BC and no network needed:
+
+    python3 scripts/merge-junit-batches.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+# One <testsuite> per codeunit, named by tools/TestRunner's JUnitWriter.Write
+# and by run-tests-altool.py's write_junit alike. A codeunit missing from this
+# set produced no result at all — not a pass, not a failure, not an
+# infrastructure-error placeholder.
+_SUITE_CODEUNIT_ID = re.compile(r"^Codeunit (\d+)$")
+
+
+def expand_expected(raw: str) -> set[int] | None:
+    """The dispatched ids as a set, or None when the list is not a definite
+    set of codeunits that exist.
+
+    run-tests.sh dispatches an EXPLICIT id list whenever it discovered the
+    codeunits from a .app's SymbolReference.json — that list is exactly what
+    compiled, so every id in it must report something. Without a .app it falls
+    back to the raw --codeunit-range, which is a literal span like
+    "50000-99999" covering mostly ids that do not exist; holding that to
+    "every id reported a result" would flag thousands of codeunits that were
+    never there. So a range token means "no definite expectation" and the
+    completeness check is skipped rather than guessed at.
+    """
+    out: set[int] = set()
+    for tok in raw.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if "-" in tok:
+            return None
+        try:
+            out.add(int(tok))
+        except ValueError:
+            return None
+    return out or None
+
+
+def merge(paths: list[str], out_path: str, expected_raw: str,
+          elapsed: float, strict: bool,
+          emit=print) -> int:
+    """Merge `paths` into `out_path`. Returns a process exit code."""
+    problems: list[str] = []
+    suites: list[ET.Element] = []
+    per_file_tests: list[int] = []
+
+    for p in paths:
+        if not os.path.isfile(p):
+            problems.append(f"batch report missing: {p}")
+            per_file_tests.append(0)
+            continue
+        try:
+            root = ET.parse(p).getroot()
+        except ET.ParseError as ex:
+            problems.append(f"batch report unreadable ({ex}): {p}")
+            per_file_tests.append(0)
+            continue
+        found = root.findall("testsuite")
+        suites.extend(found)
+        per_file_tests.append(sum(int(s.get("tests", "0")) for s in found))
+
+    def isum(attr: str) -> int:
+        return sum(int(s.get(attr, "0")) for s in suites)
+
+    total, failed = isum("tests"), isum("failures")
+    errors, skipped = isum("errors"), isum("skipped")
+    passed = total - failed - skipped - errors
+
+    merged = ET.Element("testsuites", {
+        "name": "DEFAULT",
+        "tests": str(total),
+        "failures": str(failed),
+        "errors": str(errors),
+        "skipped": str(skipped),
+        "time": f"{elapsed:.3f}",
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    })
+    for s in suites:
+        merged.append(s)
+    parent = os.path.dirname(out_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    ET.ElementTree(merged).write(out_path, encoding="unicode", xml_declaration=True)
+
+    # If the roll-up and the batches disagree, the merge dropped something and
+    # no count printed below can be trusted.
+    if total != sum(per_file_tests):
+        problems.append(
+            f"merged total {total} != sum of batch totals {sum(per_file_tests)} "
+            f"({', '.join(str(n) for n in per_file_tests)})")
+
+    seen = {int(m.group(1)) for s in suites
+            for m in [_SUITE_CODEUNIT_ID.match(s.get("name") or "")] if m}
+    expected = expand_expected(expected_raw)
+
+    emit("")
+    if expected is None:
+        if len(paths) > 1:
+            emit(f"Merged {len(paths)} batches; the dispatched list is a literal "
+                 f"range, so per-codeunit completeness is not checkable.")
+    else:
+        missing = sorted(expected - seen)
+        if missing:
+            shown = ",".join(str(i) for i in missing[:40])
+            emit(f"{'ERROR' if strict else 'WARN'}: {len(missing)} of {len(expected)} "
+                 f"codeunit(s) produced NO result at all — no <testsuite>, not even a "
+                 f"failure — in the merged report: {shown}"
+                 f"{' ...' if len(missing) > 40 else ''}")
+            if strict:
+                problems.append(f"{len(missing)} codeunit(s) reported nothing")
+        elif len(paths) > 1:
+            emit(f"All {len(expected)} dispatched codeunit(s) reported results "
+                 f"across {len(paths)} batches.")
+
+    for problem in problems:
+        emit(f"ERROR: {problem}")
+
+    # Keep this exact shape — bc-test-from-source.yml greps
+    # '[0-9]+ total, [0-9]+ passed, [0-9]+ failed' and takes the LAST match,
+    # so this has to be the run's aggregate and has to come after every
+    # batch's own summary line.
+    emit(f"{total} total, {passed} passed, {failed} failed, "
+         f"{skipped} skipped, {errors} codeunit error(s) in {elapsed:.0f}s")
+
+    return 1 if problems else 0
+
+
+# --------------------------------------------------------------------------
+# Self-test
+# --------------------------------------------------------------------------
+
+def _write_batch(path: str, cases: dict[int, tuple[int, int, int]]) -> None:
+    """cases: {codeunit_id: (passed, failed, skipped)}."""
+    parts = ['<?xml version="1.0" encoding="utf-8"?>', '<testsuites name="DEFAULT">']
+    for cu, (p, f, s) in cases.items():
+        parts.append(
+            f'  <testsuite name="Codeunit {cu}" tests="{p + f + s}" '
+            f'failures="{f}" errors="0" skipped="{s}" time="1.000">')
+        for i in range(p):
+            parts.append(f'    <testcase classname="Codeunit {cu}" name="p{i}" time="0.1"/>')
+        for i in range(f):
+            parts.append(f'    <testcase classname="Codeunit {cu}" name="f{i}" time="0.1">'
+                         f'<failure message="boom" type="AssertionFailure">boom</failure></testcase>')
+        for i in range(s):
+            parts.append(f'    <testcase classname="Codeunit {cu}" name="s{i}" time="0.1">'
+                         f'<skipped/></testcase>')
+        parts.append("  </testsuite>")
+    parts.append("</testsuites>")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(parts))
+
+
+def self_test() -> int:
+    failures: list[str] = []
+    lines: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        print(("  PASS  " if cond else "  FAIL  ") + label)
+        if not cond:
+            failures.append(label)
+
+    def run(paths, expected, strict, out):
+        lines.clear()
+        rc = merge(paths, out, expected, 12.0, strict, emit=lines.append)
+        return rc, "\n".join(lines)
+
+    print("merge:")
+    with tempfile.TemporaryDirectory() as d:
+        b1 = os.path.join(d, "b1.xml")
+        b2 = os.path.join(d, "b2.xml")
+        out = os.path.join(d, "merged.xml")
+        _write_batch(b1, {60100: (3, 0, 0), 60101: (2, 1, 0)})
+        _write_batch(b2, {60102: (4, 0, 1)})
+
+        rc, text = run([b1, b2], "60100,60101,60102", True, out)
+        check("a clean two-batch merge succeeds", rc == 0)
+        check("the aggregate line sums BOTH batches, not just the last",
+              "11 total, 9 passed, 1 failed, 1 skipped" in text)
+        check("the aggregate line is the LAST line printed",
+              text.strip().splitlines()[-1].startswith("11 total,"))
+        root = ET.parse(out).getroot()
+        check("the merged file carries every codeunit's testsuite",
+              {s.get("name") for s in root.findall("testsuite")} ==
+              {"Codeunit 60100", "Codeunit 60101", "Codeunit 60102"})
+        check("the merged roll-up matches the elements it contains",
+              root.get("tests") == "11" and root.get("failures") == "1"
+              and root.get("skipped") == "1")
+        check("completeness is reported positively when nothing is missing",
+              "All 3 dispatched codeunit(s) reported results" in text)
+
+        # The failure this file exists to catch: batch 2 never made it.
+        rc, text = run([b1], "60100,60101,60102", True, out)
+        check("a DROPPED batch fails the run in strict mode", rc == 1)
+        check("the dropped batch's codeunit is named", "60102" in text)
+        check("a dropped batch does NOT quietly report a smaller green run",
+              "ERROR:" in text)
+
+        # A batch that ran but whose report never landed.
+        rc, text = run([b1, os.path.join(d, "gone.xml")], "60100,60101,60102", True, out)
+        check("a MISSING batch report fails the run", rc == 1)
+        check("the missing report path is named", "gone.xml" in text)
+
+        # Unreadable report (truncated write, killed process).
+        bad = os.path.join(d, "bad.xml")
+        with open(bad, "w", encoding="utf-8") as fh:
+            fh.write("<testsuites name=\"DEFAULT\"><testsuite ")
+        rc, text = run([b1, bad], "60100,60101", True, out)
+        check("an UNREADABLE batch report fails the run", rc == 1)
+
+        # Non-strict: the same missing codeunit is reported, not fatal. This is
+        # the un-batched path, where nothing was split and a codeunit with no
+        # results is a pre-existing condition, not something batching caused.
+        rc, text = run([b1], "60100,60101,60102", False, out)
+        check("non-strict reports the same gap as a WARN and does not fail",
+              rc == 0 and "WARN:" in text and "60102" in text)
+
+        # A literal range says nothing about which ids exist, so the
+        # completeness check stands down rather than flagging every id in the
+        # span. It must NOT quietly become a pass-everything mode for explicit
+        # lists, which the checks above cover.
+        rc, text = run([b1, b2], "50000-99999", True, out)
+        check("a literal range skips the completeness check instead of guessing",
+              rc == 0 and "not checkable" in text)
+        rc, text = run([b1, b2], "60100,60101,60102,60103", True, out)
+        check("an explicit list right after a range still catches a gap",
+              rc == 1 and "60103" in text)
+
+        # Single batch, everything present: the ordinary un-batched run.
+        rc, text = run([b1], "60100,60101", True, out)
+        check("a single complete batch succeeds", rc == 0)
+        check("a single batch still prints an aggregate line",
+              "6 total, 5 passed, 1 failed" in text)
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed: {', '.join(failures)}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(
+        description="Merge per-batch JUnit reports and verify nothing was lost.")
+    ap.add_argument("batches", nargs="*", help="per-batch JUnit XML files, in order")
+    ap.add_argument("--out", default="", help="where to write the merged report")
+    ap.add_argument("--expected", default="",
+                    help="comma-separated codeunit ids that were dispatched")
+    ap.add_argument("--elapsed", type=float, default=0.0, help="wall seconds")
+    ap.add_argument("--strict", action="store_true",
+                    help="fail when a dispatched codeunit reported nothing")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the built-in checks and exit; needs no BC")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+    if not args.out:
+        print("ERROR: --out is required", file=sys.stderr)
+        return 2
+    if not args.batches:
+        print("ERROR: no batch reports given", file=sys.stderr)
+        return 2
+    return merge(args.batches, args.out, args.expected, args.elapsed, args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -351,43 +351,103 @@ if [ -z "$CODEUNIT_IDS" ]; then
 fi
 echo "Test codeunits: $CODEUNIT_IDS"
 
-# === Setup Test Suite via OData ===
-echo -n "Setting up test suite... "
-CREATE_BODY=$(mktemp)
-CREATE_HTTP=$(curl -s -o "$CREATE_BODY" -w "%{http_code}" --max-time 15 -u "$AUTH" -X POST \
-    -H "Content-Type: application/json" \
-    -d "{\"CodeunitIds\": \"$CODEUNIT_IDS\"}" \
-    "${API_BASE}/codeunitRunRequests" 2>/dev/null)
-REQUEST_ID=$(py3 -c "import sys,json; print(json.load(sys.stdin)['Id'])" < "$CREATE_BODY" 2>/dev/null || true)
-
-if [ -z "$REQUEST_ID" ]; then
-    echo "FAIL (could not create request)"
-    echo ""
-    echo "ERROR: POST ${API_BASE}/codeunitRunRequests"
-    echo "       HTTP code: $CREATE_HTTP"
-    echo "       Request body: {\"CodeunitIds\": \"$CODEUNIT_IDS\"}"
-    echo "       Response body:"
-    sed 's/^/         /' "$CREATE_BODY"
-    echo ""
-    echo "       Likely causes:"
-    echo "         - The custom TestRunner extension (page 99902 'Codeunit Run Requests')"
-    echo "           is not installed for the default tenant. Check 'Test Runner Extension'"
-    echo "           in entrypoint.sh's BC startup logs."
-    echo "         - The OData endpoint we're hitting (\$API_PORT_BASE) is wrong for"
-    echo "           POST in this BC version (the auto-detection picked an endpoint that"
-    echo "           accepts GET on this path but not POST)."
-    echo "         - The request body schema doesn't match the page's bound action."
-    rm -f "$CREATE_BODY"
+# === Split the codeunit list into batches BC's API will accept ===
+#
+# The suite is populated by POSTing the codeunit ids as ONE string field,
+# `CodeunitIds: Text[2048]` on table 99903. Past 2048 characters BC rejects
+# the POST with HTTP 400 Application_StringExceededLength and the run dies
+# before a single test executes — nothing has failed, the list is simply too
+# long. StefanMaron/BusinessCentral.AL.Language.Tests walked into that on
+# 2026-09-05 at 342 test codeunits / 2051 characters, three over.
+#
+# So: split the list, and set the suite up and run it once per batch.
+# SetupSuite calls InitSuite, which CLEARS the DEFAULT suite, so batches
+# cannot be accumulated into one suite and then run together — each batch has
+# to be set up and executed before the next one replaces it. Batches are
+# contiguous slices in discovery order, so the execution order is the same as
+# an un-batched run's.
+#
+# scripts/chunk-codeunit-ids.py owns the split and proves it is total (nothing
+# dropped, duplicated or reordered) before returning; `--self-test` exercises
+# that without a BC container. The default budget is well under 2048 on
+# purpose — see DEFAULT_MAX_CHARS there.
+CODEUNIT_IDS_MAX_CHARS="${BC_CODEUNIT_IDS_MAX_CHARS:-1000}"
+CHUNKS=()
+CHUNK_LIST_FILE=$(mktemp)
+CHUNK_SPLIT_RC=0
+py3 "$REPO_DIR/scripts/chunk-codeunit-ids.py" \
+    --max-chars "$CODEUNIT_IDS_MAX_CHARS" "$CODEUNIT_IDS" > "$CHUNK_LIST_FILE" || CHUNK_SPLIT_RC=$?
+if [ "$CHUNK_SPLIT_RC" -ne 0 ]; then
+    echo "ERROR: could not split the codeunit id list into API-sized batches (rc=$CHUNK_SPLIT_RC)"
+    echo "       List was ${#CODEUNIT_IDS} chars: $CODEUNIT_IDS"
+    rm -f "$CHUNK_LIST_FILE"
     exit 1
 fi
-rm -f "$CREATE_BODY"
-
-SETUP_HTTP=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -u "$AUTH" -X POST \
-    "${API_BASE}/codeunitRunRequests(${REQUEST_ID})/Microsoft.NAV.setupSuite" 2>/dev/null)
-if [ "$SETUP_HTTP" != "200" ] && [ "$SETUP_HTTP" != "204" ]; then
-    echo "FAIL (HTTP $SETUP_HTTP)"
+# Read the whole list into an array BEFORE the execution loop. The loop body
+# runs curl and `docker compose exec`, and a child that reads stdin would eat
+# the rest of a `while read` redirection — the loop would then run once and
+# look like it had run to completion.
+while IFS= read -r _chunk_line; do
+    [ -n "$_chunk_line" ] && CHUNKS+=("$_chunk_line")
+done < "$CHUNK_LIST_FILE"
+rm -f "$CHUNK_LIST_FILE"
+if [ ${#CHUNKS[@]} -eq 0 ]; then
+    echo "ERROR: codeunit id split produced no batches"
     exit 1
 fi
+if [ ${#CHUNKS[@]} -gt 1 ]; then
+    echo "Codeunit id list is ${#CODEUNIT_IDS} chars; BC's CodeunitIds field holds 2048."
+    echo "Running in ${#CHUNKS[@]} batches of at most ${CODEUNIT_IDS_MAX_CHARS} chars each."
+fi
+
+# === Setup Test Suite via OData (per batch) ===
+REQUEST_ID=""
+setup_suite_chunk() {
+    local chunk="$1" label="$2"
+    echo -n "Setting up test suite${label}... "
+    local create_body create_http
+    create_body=$(mktemp)
+    create_http=$(curl -s -o "$create_body" -w "%{http_code}" --max-time 15 -u "$AUTH" -X POST \
+        -H "Content-Type: application/json" \
+        -d "{\"CodeunitIds\": \"$chunk\"}" \
+        "${API_BASE}/codeunitRunRequests" 2>/dev/null)
+    REQUEST_ID=$(py3 -c "import sys,json; print(json.load(sys.stdin)['Id'])" < "$create_body" 2>/dev/null || true)
+
+    if [ -z "$REQUEST_ID" ]; then
+        echo "FAIL (could not create request)"
+        echo ""
+        echo "ERROR: POST ${API_BASE}/codeunitRunRequests"
+        echo "       HTTP code: $create_http"
+        echo "       Request body: {\"CodeunitIds\": \"$chunk\"}"
+        echo "       CodeunitIds length: ${#chunk} chars (BC's field limit is 2048)"
+        echo "       Response body:"
+        sed 's/^/         /' "$create_body"
+        echo ""
+        echo "       Likely causes:"
+        echo "         - The custom TestRunner extension (page 99902 'Codeunit Run Requests')"
+        echo "           is not installed for the default tenant. Check 'Test Runner Extension'"
+        echo "           in entrypoint.sh's BC startup logs."
+        echo "         - The OData endpoint we're hitting (\$API_PORT_BASE) is wrong for"
+        echo "           POST in this BC version (the auto-detection picked an endpoint that"
+        echo "           accepts GET on this path but not POST)."
+        echo "         - The request body schema doesn't match the page's bound action."
+        echo "         - Application_StringExceededLength above means the batch is still"
+        echo "           too long — lower BC_CODEUNIT_IDS_MAX_CHARS (currently"
+        echo "           ${CODEUNIT_IDS_MAX_CHARS})."
+        rm -f "$create_body"
+        return 1
+    fi
+    rm -f "$create_body"
+
+    local setup_http
+    setup_http=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -u "$AUTH" -X POST \
+        "${API_BASE}/codeunitRunRequests(${REQUEST_ID})/Microsoft.NAV.setupSuite" 2>/dev/null)
+    if [ "$setup_http" != "200" ] && [ "$setup_http" != "204" ]; then
+        echo "FAIL (HTTP $setup_http)"
+        return 1
+    fi
+    return 0
+}
 
 # === Verify the suite was populated ===
 #
@@ -460,13 +520,13 @@ sys.exit(0 if matched else 1)
     return 1
 }
 
-echo ""   # newline so per-attempt logs are readable
-if ! verify_suite_populated "$REQUEST_ID" "$CODEUNIT_IDS"; then
+report_verify_failure() {
+    local chunk="$1"
     echo ""
     echo "ERROR: setupSuite returned 200 but the DEFAULT test suite never"
     echo "       contained any of the expected codeunits after 20 retries (~40s)."
     echo ""
-    echo "       Expected codeunit IDs: $CODEUNIT_IDS"
+    echo "       Expected codeunit IDs: $chunk"
     echo ""
     echo "       Last verify detail:    $VERIFY_LAST_DETAIL"
     echo ""
@@ -484,11 +544,17 @@ if ! verify_suite_populated "$REQUEST_ID" "$CODEUNIT_IDS"; then
     echo "       Cross-check installed extensions:"
     echo "         curl -u $AUTH '${BASE_URL}/api/v2.0/extensionDeployments'"
     echo "         curl -u $AUTH '${_API_FALLBACK}/api/v2.0/extensionDeployments'"
-    exit 1
-fi
-echo "Test suite populated."
+}
 
 # === Disable Known-Failing Tests ===
+#
+# Parsed once; APPLIED once per batch. Each batch's setupSuite calls
+# InitSuite, which deletes the DEFAULT suite's Test Method Line rows —
+# including the Run=false flags a previous batch's disableTests set. Applying
+# the disables outside the loop would silently re-enable every disabled test
+# from the second batch onwards.
+DISABLED_ENTRIES=""
+DISABLED_FILE_COUNT=0
 if [ -n "$DISABLED_TESTS_DIR" ] && [ -d "$DISABLED_TESTS_DIR" ]; then
     # Read each DisabledTests JSON file individually (concatenating produces invalid JSON)
     # BCApps format per file: [{"codeunitId": 132920, "method": "TestName"}, ...]
@@ -523,26 +589,37 @@ if current:
 for c in chunks:
     print(c)
 " "$DISABLED_TESTS_DIR" 2>/dev/null)
-    echo "Parsed disabled tests from $(find "$DISABLED_TESTS_DIR" -name '*.json' | wc -l) files"
-
-    if [ -n "$DISABLED_ENTRIES" ]; then
-        DISABLED_COUNT=0
-        while IFS= read -r CHUNK; do
-            # Create a request and call DisableTests
-            DIS_RESP=$(curl -s --max-time 15 -u "$AUTH" -X POST \
-                -H "Content-Type: application/json" \
-                -d "{\"CodeunitIds\": \"$CHUNK\"}" \
-                "${API_BASE}/codeunitRunRequests" 2>/dev/null)
-            DIS_ID=$(echo "$DIS_RESP" | py3 -c "import sys,json; print(json.load(sys.stdin)['Id'])" 2>/dev/null || true)
-            if [ -n "$DIS_ID" ]; then
-                curl -s -o /dev/null --max-time 30 -u "$AUTH" -X POST \
-                    "${API_BASE}/codeunitRunRequests(${DIS_ID})/Microsoft.NAV.disableTests" 2>/dev/null
-                DISABLED_COUNT=$((DISABLED_COUNT + 1))
-            fi
-        done <<< "$DISABLED_ENTRIES"
-        echo "Disabled tests: $DISABLED_COUNT chunk(s) from $(find "$DISABLED_TESTS_DIR" -name "*.json" | wc -l) file(s)"
-    fi
+    DISABLED_FILE_COUNT=$(find "$DISABLED_TESTS_DIR" -name '*.json' | wc -l)
+    echo "Parsed disabled tests from $DISABLED_FILE_COUNT files"
 fi
+
+# Same reason as the batch list above: materialise into an array first, so
+# nothing inside the apply loop can eat the input stream.
+DISABLED_CHUNKS=()
+if [ -n "$DISABLED_ENTRIES" ]; then
+    while IFS= read -r _dis_line; do
+        [ -n "$_dis_line" ] && DISABLED_CHUNKS+=("$_dis_line")
+    done <<< "$DISABLED_ENTRIES"
+fi
+
+apply_disabled_tests() {
+    [ ${#DISABLED_CHUNKS[@]} -eq 0 ] && return 0
+    local applied=0 dis_chunk dis_resp dis_id
+    for dis_chunk in "${DISABLED_CHUNKS[@]}"; do
+        dis_resp=$(curl -s --max-time 15 -u "$AUTH" -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"CodeunitIds\": \"$dis_chunk\"}" \
+            "${API_BASE}/codeunitRunRequests" 2>/dev/null)
+        dis_id=$(echo "$dis_resp" | py3 -c "import sys,json; print(json.load(sys.stdin)['Id'])" 2>/dev/null || true)
+        if [ -n "$dis_id" ]; then
+            curl -s -o /dev/null --max-time 30 -u "$AUTH" -X POST \
+                "${API_BASE}/codeunitRunRequests(${dis_id})/Microsoft.NAV.disableTests" 2>/dev/null
+            applied=$((applied + 1))
+        fi
+    done
+    echo "Disabled tests: $applied chunk(s) from $DISABLED_FILE_COUNT file(s)"
+    return 0
+}
 
 # === Execute Tests via WebSocket ===
 echo ""
@@ -558,12 +635,6 @@ ODATA_HOST="${BC_HOST}:7052"
 # Parse auth components
 AUTH_USER="${AUTH%%:*}"
 AUTH_PASS="${AUTH#*:}"
-
-# Calculate max iterations: each codeunit needs ~2 iterations (run + reconnect after isolation)
-IFS=',' read -ra CU_ARRAY <<< "$CODEUNIT_IDS"
-NUM_CODEUNITS=${#CU_ARRAY[@]}
-MAX_ITER=$(( NUM_CODEUNITS * 3 + 20 ))
-echo "Executing $NUM_CODEUNITS codeunits via WebSocket (max $MAX_ITER iterations)..."
 
 # Note: do NOT pass --codeunit-filter here — the suite is already set up via OData.
 # Passing it would re-trigger SetupSuite which clears test results.
@@ -607,94 +678,7 @@ if [ "$USE_DOCKER_EXEC" = "false" ]; then
         fi
     done
 fi
-
-if [ "$USE_DOCKER_EXEC" = "true" ]; then
-    # Inside the container, BC's WebSocket and API ports are local to the
-    # container itself, so always use localhost regardless of how the host
-    # has them mapped. The TestRunner.dll path is fixed by the Dockerfile.
-    #
-    # --verbose is now passed by default. Without it, every Log() message
-    # in TestRunner.dll is silently swallowed (the function gates on a
-    # `verbose` flag and writes to stderr only when set). That made the
-    # bc-copilot-blueprint debugging session needlessly painful: the
-    # runner would exit with "0 total, 0 passed, 0 failed" in 0 seconds
-    # and there was no way to see *why* — whether it was a connection
-    # failure, an empty suite, "All tests executed" on the first iter,
-    # or anything else. Verbose stderr is cheap and the right default.
-    #
-    # JUnit output: when --junit-output is set, TestRunner writes inside
-    # the container to /tmp/junit-result.xml, then we docker cp it back
-    # to the caller-supplied host path. This avoids needing to bind-mount
-    # the destination path.
-    JUNIT_FLAGS=()
-    if [ -n "$JUNIT_OUTPUT" ]; then
-        JUNIT_FLAGS+=(--junit-output /tmp/junit-result.xml)
-    fi
-    ( cd "$REPO_DIR" && printf '%s' "$AUTH_PASS" | docker compose exec -T bc \
-        env DOTNET_STARTUP_HOOKS= dotnet /bc/tools/TestRunner/TestRunner.dll \
-        --verbose \
-        --host "localhost:7085" \
-        --odata-host "localhost:7052" \
-        --company "$COMPANY" \
-        --user "$AUTH_USER" \
-        --password-stdin \
-        --suite "DEFAULT" \
-        --num-codeunits "$NUM_CODEUNITS" \
-        --timeout "$TIMEOUT_MIN" \
-        --codeunit-timeout 10 \
-        --max-iterations "$MAX_ITER" \
-        "${JUNIT_FLAGS[@]}" )
-    EXIT_CODE=$?
-    if [ -n "$JUNIT_OUTPUT" ]; then
-        # Pull the in-container JUnit file out to the host.
-        mkdir -p "$(dirname "$JUNIT_OUTPUT")"
-        if ( cd "$REPO_DIR" && docker compose cp bc:/tmp/junit-result.xml "$JUNIT_OUTPUT" 2>/dev/null ); then
-            echo "[run-tests] JUnit XML copied to $JUNIT_OUTPUT"
-        else
-            echo "[run-tests] WARN: TestRunner did not produce /tmp/junit-result.xml inside the container"
-        fi
-    fi
-elif [ -n "$HOST_PREBUILT" ]; then
-    # Pre-built binary on the host — no SDK needed, just the .NET 8 runtime.
-    echo "[run-tests] Using pre-built TestRunner at $HOST_PREBUILT"
-    JUNIT_FLAGS=()
-    if [ -n "$JUNIT_OUTPUT" ]; then
-        JUNIT_FLAGS+=(--junit-output "$JUNIT_OUTPUT")
-    fi
-    printf '%s' "$AUTH_PASS" | dotnet "$HOST_PREBUILT" \
-        --verbose \
-        --host "$WS_HOST" \
-        --odata-host "$ODATA_HOST" \
-        --company "$COMPANY" \
-        --user "$AUTH_USER" \
-        --password-stdin \
-        --suite "DEFAULT" \
-        --num-codeunits "$NUM_CODEUNITS" \
-        --timeout "$TIMEOUT_MIN" \
-        --codeunit-timeout 10 \
-        --max-iterations "$MAX_ITER" \
-        "${JUNIT_FLAGS[@]}"
-    EXIT_CODE=$?
-elif command -v dotnet >/dev/null 2>&1; then
-    JUNIT_FLAGS=()
-    if [ -n "$JUNIT_OUTPUT" ]; then
-        JUNIT_FLAGS+=(--junit-output "$JUNIT_OUTPUT")
-    fi
-    printf '%s' "$AUTH_PASS" | dotnet run --project "$REPO_DIR/tools/TestRunner" -v q -- \
-        --verbose \
-        --host "$WS_HOST" \
-        --odata-host "$ODATA_HOST" \
-        --company "$COMPANY" \
-        --user "$AUTH_USER" \
-        --password-stdin \
-        --suite "DEFAULT" \
-        --num-codeunits "$NUM_CODEUNITS" \
-        --timeout "$TIMEOUT_MIN" \
-        --codeunit-timeout 10 \
-        --max-iterations "$MAX_ITER" \
-        "${JUNIT_FLAGS[@]}"
-    EXIT_CODE=$?
-else
+if [ "$USE_DOCKER_EXEC" = "false" ] && [ -z "$HOST_PREBUILT" ] && ! command -v dotnet >/dev/null 2>&1; then
     echo "ERROR: cannot run TestRunner — no execution method available."
     echo "  Tried (in order):"
     echo "    1. docker compose exec bc (container not found or missing TestRunner.dll)"
@@ -706,6 +690,180 @@ else
     exit 1
 fi
 
-# The TestRunner already reads and prints results via OData.
-# Its exit code: 0 = all pass, 1 = failures or no tests.
-exit $EXIT_CODE
+# Runs ONE batch. $1 = codeunit count (for the runner's progress display and
+# its own "did every codeunit run" check), $2 = where to write this batch's
+# JUnit XML. Always emits JUnit, even when the caller did not ask for a file:
+# the merge step below needs it to prove no batch went missing.
+execute_chunk() {
+    local num_codeunits="$1" junit_path="$2"
+    local max_iter=$(( num_codeunits * 3 + 20 ))
+    local rc=0
+    mkdir -p "$(dirname "$junit_path")"
+    rm -f "$junit_path"
+    if [ "$USE_DOCKER_EXEC" = "true" ]; then
+        # Inside the container, BC's WebSocket and API ports are local to the
+        # container itself, so always use localhost regardless of how the host
+        # has them mapped. The TestRunner.dll path is fixed by the Dockerfile.
+        #
+        # --verbose is now passed by default. Without it, every Log() message
+        # in TestRunner.dll is silently swallowed (the function gates on a
+        # `verbose` flag and writes to stderr only when set). That made the
+        # bc-copilot-blueprint debugging session needlessly painful: the
+        # runner would exit with "0 total, 0 passed, 0 failed" in 0 seconds
+        # and there was no way to see *why* — whether it was a connection
+        # failure, an empty suite, "All tests executed" on the first iter,
+        # or anything else. Verbose stderr is cheap and the right default.
+        #
+        # JUnit output: TestRunner writes to a per-batch path inside the
+        # container, which we then docker cp back to the host path for this
+        # batch. Avoids needing to bind-mount the destination, and a per-batch
+        # name means a batch can never copy out the PREVIOUS batch's report if
+        # its own write failed — the copy fails instead, and the merge step
+        # turns that into a loud error rather than a duplicated result set.
+        local in_container_junit="/tmp/$(basename "$junit_path")"
+        ( cd "$REPO_DIR" && printf '%s' "$AUTH_PASS" | docker compose exec -T bc \
+            env DOTNET_STARTUP_HOOKS= dotnet /bc/tools/TestRunner/TestRunner.dll \
+            --verbose \
+            --host "localhost:7085" \
+            --odata-host "localhost:7052" \
+            --company "$COMPANY" \
+            --user "$AUTH_USER" \
+            --password-stdin \
+            --suite "DEFAULT" \
+            --num-codeunits "$num_codeunits" \
+            --timeout "$TIMEOUT_MIN" \
+            --codeunit-timeout 10 \
+            --max-iterations "$max_iter" \
+            --junit-output "$in_container_junit" )
+        rc=$?
+        # </dev/null: `docker compose cp` inherits this script's stdin, and
+        # run-tests.sh is itself called from a `while read ... done <<<` loop
+        # in bc-test-from-source.yml. A child that reads stdin eats the rest
+        # of that here-string and the caller's loop silently runs once.
+        if ( cd "$REPO_DIR" && docker compose cp "bc:$in_container_junit" "$junit_path" </dev/null 2>/dev/null ); then
+            echo "[run-tests] JUnit XML copied to $junit_path"
+        else
+            echo "[run-tests] WARN: TestRunner did not produce $in_container_junit inside the container"
+        fi
+    elif [ -n "$HOST_PREBUILT" ]; then
+        # Pre-built binary on the host — no SDK needed, just the .NET 8 runtime.
+        echo "[run-tests] Using pre-built TestRunner at $HOST_PREBUILT"
+        printf '%s' "$AUTH_PASS" | dotnet "$HOST_PREBUILT" \
+            --verbose \
+            --host "$WS_HOST" \
+            --odata-host "$ODATA_HOST" \
+            --company "$COMPANY" \
+            --user "$AUTH_USER" \
+            --password-stdin \
+            --suite "DEFAULT" \
+            --num-codeunits "$num_codeunits" \
+            --timeout "$TIMEOUT_MIN" \
+            --codeunit-timeout 10 \
+            --max-iterations "$max_iter" \
+            --junit-output "$junit_path"
+        rc=$?
+    else
+        printf '%s' "$AUTH_PASS" | dotnet run --project "$REPO_DIR/tools/TestRunner" -v q -- \
+            --verbose \
+            --host "$WS_HOST" \
+            --odata-host "$ODATA_HOST" \
+            --company "$COMPANY" \
+            --user "$AUTH_USER" \
+            --password-stdin \
+            --suite "DEFAULT" \
+            --num-codeunits "$num_codeunits" \
+            --timeout "$TIMEOUT_MIN" \
+            --codeunit-timeout 10 \
+            --max-iterations "$max_iter" \
+            --junit-output "$junit_path"
+        rc=$?
+    fi
+    return $rc
+}
+
+# --- The batch loop ---
+CHUNK_JUNIT_DIR=$(mktemp -d)
+CHUNK_JUNITS=()
+OVERALL_RC=0
+BATCHES_EXECUTED=0
+RUN_START_TS=$(date +%s)
+
+CHUNK_INDEX=0
+for CHUNK in "${CHUNKS[@]}"; do
+    CHUNK_INDEX=$((CHUNK_INDEX + 1))
+    CHUNK_LABEL=""
+    [ ${#CHUNKS[@]} -gt 1 ] && CHUNK_LABEL=" (batch $CHUNK_INDEX/${#CHUNKS[@]})"
+
+    IFS=',' read -ra CU_ARRAY <<< "$CHUNK"
+    NUM_CODEUNITS=${#CU_ARRAY[@]}
+
+    if ! setup_suite_chunk "$CHUNK" "$CHUNK_LABEL"; then
+        rm -rf "$CHUNK_JUNIT_DIR"
+        exit 1
+    fi
+
+    echo ""   # newline so per-attempt logs are readable
+    if ! verify_suite_populated "$REQUEST_ID" "$CHUNK"; then
+        report_verify_failure "$CHUNK"
+        rm -rf "$CHUNK_JUNIT_DIR"
+        exit 1
+    fi
+    echo "Test suite populated${CHUNK_LABEL}."
+
+    apply_disabled_tests
+
+    CHUNK_JUNIT="$CHUNK_JUNIT_DIR/batch-$CHUNK_INDEX.xml"
+    echo "Executing $NUM_CODEUNITS codeunits via WebSocket${CHUNK_LABEL}..."
+    execute_chunk "$NUM_CODEUNITS" "$CHUNK_JUNIT"
+    CHUNK_RC=$?
+    BATCHES_EXECUTED=$((BATCHES_EXECUTED + 1))
+    CHUNK_JUNITS+=("$CHUNK_JUNIT")
+    [ "$CHUNK_RC" -ne 0 ] && OVERALL_RC=1
+done
+
+# A batch that never ran is the failure mode this whole change could
+# introduce, and it would look exactly like a smaller green run. Assert it
+# directly rather than inferring it from the totals.
+if [ "$BATCHES_EXECUTED" -ne "${#CHUNKS[@]}" ]; then
+    echo "ERROR: $BATCHES_EXECUTED of ${#CHUNKS[@]} batch(es) were executed — the rest never ran"
+    rm -rf "$CHUNK_JUNIT_DIR"
+    exit 1
+fi
+
+# === Merge the batches into one report ===
+#
+# The per-batch JUnit files are disjoint by construction (each codeunit is in
+# exactly one batch), so merging is a concatenation of <testsuite> elements
+# with the roll-up attributes recomputed. Same shape run-tests-hybrid.py
+# produces, so downstream consumers cannot tell a batched run from a
+# single-request one.
+TOTAL_ELAPSED=$(( $(date +%s) - RUN_START_TS ))
+MERGED_JUNIT="$JUNIT_OUTPUT"
+[ -z "$MERGED_JUNIT" ] && MERGED_JUNIT="$CHUNK_JUNIT_DIR/merged.xml"
+
+# STRICT_COMPLETENESS: when the list was batched, a codeunit that produced no
+# <testsuite> at all means a batch was lost somewhere between dispatch and the
+# report, and that must fail the run (issue #57 is the same false-green
+# shape). On a single un-batched batch the check is reported but not fatal —
+# no batching happened, so a missing codeunit is a pre-existing condition this
+# change did not cause and must not newly re-verdict.
+STRICT_COMPLETENESS=0
+[ ${#CHUNKS[@]} -gt 1 ] && STRICT_COMPLETENESS=1
+
+STRICT_FLAG=()
+[ "$STRICT_COMPLETENESS" = "1" ] && STRICT_FLAG=(--strict)
+py3 "$REPO_DIR/scripts/merge-junit-batches.py" \
+    --out "$MERGED_JUNIT" \
+    --expected "$CODEUNIT_IDS" \
+    --elapsed "$TOTAL_ELAPSED" \
+    "${STRICT_FLAG[@]}" \
+    "${CHUNK_JUNITS[@]}"
+MERGE_RC=$?
+[ "$MERGE_RC" -ne 0 ] && OVERALL_RC=1
+
+if [ -n "$JUNIT_OUTPUT" ] && [ -f "$JUNIT_OUTPUT" ]; then
+    echo "JUnit XML written to $JUNIT_OUTPUT"
+fi
+rm -rf "$CHUNK_JUNIT_DIR"
+
+exit $OVERALL_RC

--- a/scripts/test-run-tests-batching.py
+++ b/scripts/test-run-tests-batching.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Drive the real scripts/run-tests.sh against a fake BC and prove its
+codeunit batching loses nothing.
+
+WHY A HARNESS AND NOT A UNIT TEST
+---------------------------------
+chunk-codeunit-ids.py proves the SPLIT is total and merge-junit-batches.py
+proves the MERGE is total, each with its own `--self-test`. Neither can see
+the thing in between: the bash loop in run-tests.sh that sets the suite up,
+runs it, and collects a report once per batch. That loop is where a batch
+would actually go missing, and a missing batch does not look like an error —
+it looks like a green run with fewer tests in it (issue #57's shape).
+
+So this runs the real script, unmodified, with `curl`, `docker` and `dotnet`
+shimmed onto PATH. The fake BC enforces the same 2048-character `CodeunitIds`
+limit real BC does, which means the pre-fix script fails here for exactly the
+reason it failed on StefanMaron/BusinessCentral.AL.Language.Tests on
+2026-09-05, and the fixed one has to actually batch to get past it.
+
+Needs no container, no network and no BC — a couple of seconds:
+
+    python3 scripts/test-run-tests-batching.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The exact shape that took the corpus red: 342 five-digit ids join to 2051
+# characters, three over BC's field width.
+CODEUNIT_IDS = [str(60000 + i) for i in range(342)]
+TESTS_PER_CODEUNIT = 2
+
+FAKE_CURL = r'''#!/usr/bin/env python3
+import json, os, re, sys
+
+STATE = os.environ["FAKEBC_STATE"]
+LIMIT = 2048            # width of CodeunitIds (Text[2048]) on table 99903
+
+def load():
+    if not os.path.isfile(STATE):
+        return {"requests": {}, "suite": [], "posts": [], "setups": 0,
+                "runs": [], "disables": 0, "next": 1}
+    with open(STATE) as f:
+        return json.load(f)
+
+args = sys.argv[1:]
+out = wfmt = data = url = None
+method = "GET"
+fail_mode = False
+i = 0
+while i < len(args):
+    a = args[i]
+    if a == "-o":   out = args[i + 1];    i += 2; continue
+    if a == "-w":   wfmt = args[i + 1];   i += 2; continue
+    if a == "-X":   method = args[i + 1]; i += 2; continue
+    if a == "-d":   data = args[i + 1];   i += 2; continue
+    if a in ("-u", "--max-time", "-H"):   i += 2; continue
+    if a.startswith("-"):
+        if "f" in a.lstrip("-"):
+            fail_mode = True
+        i += 1
+        continue
+    url = a
+    i += 1
+
+s = load()
+code, body = 404, ""
+
+if url.endswith("/ODataV4/Company"):
+    code, body = 200, json.dumps({"value": [
+        {"Name": "CRONUS", "Id": "aaa-bbb", "Evaluation_Company": True}]})
+elif url.endswith("/api/v2.0/companies"):
+    code, body = 200, json.dumps({"value": [{"name": "CRONUS", "id": "aaa-bbb"}]})
+elif "Microsoft.NAV.setupSuite" in url:
+    rid = re.search(r"codeunitRunRequests\(([^)]+)\)", url).group(1)
+    s["suite"] = [t for t in s["requests"][rid].split(",") if t]
+    s["setups"] += 1
+    code = 200
+elif "Microsoft.NAV.disableTests" in url:
+    s["disables"] += 1
+    code = 200
+elif url.rstrip("/").endswith("/codeunitRunRequests") and method == "POST":
+    ids = json.loads(data)["CodeunitIds"]
+    s["posts"].append(ids)
+    if len(ids) > LIMIT:
+        # Byte-for-byte the error real BC returns; this is the bug.
+        code, body = 400, json.dumps({"error": {
+            "code": "Application_StringExceededLength",
+            "message": "The length of the string is %d, but it must be less "
+                       "than or equal to %d characters." % (len(ids), LIMIT)}})
+    else:
+        rid = "req-%d" % s["next"]
+        s["next"] += 1
+        s["requests"][rid] = ids
+        code, body = 200, json.dumps({"Id": rid, "CodeunitIds": ids})
+elif url.rstrip("/").endswith("/codeunitRunRequests"):
+    code, body = 200, json.dumps({"value": []})
+elif "/testResults" in url:
+    per = int(os.environ.get("FAKEBC_TESTS_PER_CU", "2"))
+    rows = [{"testSuite": "DEFAULT", "lineType": "Function",
+             "testCodeunit": int(cu), "functionName": "T%d" % n}
+            for cu in s["suite"] for n in range(per)]
+    code, body = 200, json.dumps({"value": rows})
+
+with open(STATE, "w") as f:
+    json.dump(s, f)
+
+if out and out != "/dev/null":
+    with open(out, "w") as f:
+        f.write(body)
+elif out != "/dev/null":
+    sys.stdout.write(body)
+if wfmt:
+    sys.stdout.write(wfmt.replace("%{http_code}", str(code)))
+sys.exit(22 if (fail_mode and code >= 400) else 0)
+'''
+
+# No compose project here, so run-tests.sh falls through to a host-side
+# dotnet — which is also shimmed.
+FAKE_DOCKER = "#!/bin/sh\nexit 1\n"
+
+FAKE_DOTNET = r'''#!/usr/bin/env python3
+import json, os, sys
+
+STATE = os.environ["FAKEBC_STATE"]
+with open(STATE) as f:
+    s = json.load(f)
+
+junit = None
+args = sys.argv[1:]
+for i, a in enumerate(args):
+    if a == "--junit-output":
+        junit = args[i + 1]
+try:
+    sys.stdin.read()          # --password-stdin
+except Exception:
+    pass
+
+suite = list(s["suite"])
+s["runs"].append(suite)
+with open(STATE, "w") as f:
+    json.dump(s, f)
+
+per = int(os.environ.get("FAKEBC_TESTS_PER_CU", "2"))
+
+# Sabotage hook: pretend the Nth batch's runner exited 0 but never wrote its
+# report. That is the false-green the completeness check has to catch, and it
+# is invisible to an exit-code check.
+if os.environ.get("FAKEBC_DROP_RUN") == str(len(s["runs"])):
+    print("0 total, 0 passed, 0 failed, 0 skipped")
+    sys.exit(0)
+
+parts = ['<?xml version="1.0" encoding="utf-8"?>', '<testsuites name="DEFAULT">']
+for cu in suite:
+    parts.append('  <testsuite name="Codeunit %s" tests="%d" failures="0" '
+                 'errors="0" skipped="0" time="0.5">' % (cu, per))
+    for n in range(per):
+        parts.append('    <testcase classname="Codeunit %s" name="T%d" time="0.1"/>'
+                     % (cu, n))
+    parts.append("  </testsuite>")
+parts.append("</testsuites>")
+if junit:
+    d = os.path.dirname(junit)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    with open(junit, "w") as f:
+        f.write("\n".join(parts))
+
+n = len(suite) * per
+print("\n=== Results (1s) ===")
+print("%d total, %d passed, 0 failed, 0 skipped" % (n, n))
+sys.exit(0 if n else 1)
+'''
+
+
+def _make_shims(root: str) -> str:
+    bindir = os.path.join(root, "bin")
+    os.makedirs(bindir, exist_ok=True)
+    for name, body in (("curl", FAKE_CURL), ("docker", FAKE_DOCKER),
+                       ("dotnet", FAKE_DOTNET)):
+        path = os.path.join(bindir, name)
+        with open(path, "w") as fh:
+            fh.write(body)
+        os.chmod(path, 0o755)
+    return bindir
+
+
+class Run:
+    def __init__(self, rc: int, out: str, state: dict, junit: str):
+        self.rc, self.out, self.state, self.junit = rc, out, state, junit
+
+    @property
+    def posts(self) -> list[str]:
+        return self.state["posts"]
+
+    @property
+    def dispatched(self) -> list[str]:
+        """Every codeunit id the runner was actually asked to execute, in
+        order, flattened across batches."""
+        return [cu for run in self.state["runs"] for cu in run]
+
+    def merged_root(self):
+        """Parsed merged report, or None. Returns None rather than raising so
+        a run that produced no report at all reports as failed checks instead
+        of a traceback — which is what the PRE-FIX script does here."""
+        try:
+            return ET.parse(self.junit).getroot()
+        except (OSError, ET.ParseError):
+            return None
+
+
+def run_case(root: str, script: str, ids: str, env: dict | None = None,
+             extra: list[str] | None = None) -> Run:
+    wd = tempfile.mkdtemp(dir=root)
+    state = os.path.join(wd, "state.json")
+    junit = os.path.join(wd, "junit.xml")
+    e = dict(os.environ)
+    e["PATH"] = _make_shims(root) + os.pathsep + e["PATH"]
+    e["FAKEBC_STATE"] = state
+    e["FAKEBC_TESTS_PER_CU"] = str(TESTS_PER_CODEUNIT)
+    e.update(env or {})
+    proc = subprocess.run(
+        [script, "--codeunit-range", ids,
+         "--base-url", "http://localhost:7048/BC",
+         "--dev-url", "http://localhost:7049/BC/dev",
+         "--junit-output", junit] + (extra or []),
+        capture_output=True, text=True, env=e, stdin=subprocess.DEVNULL)
+    with open(state) as fh:
+        st = json.load(fh)
+    return Run(proc.returncode, proc.stdout + proc.stderr, st, junit)
+
+
+def main() -> int:
+    script = os.path.join(REPO, "scripts", "run-tests.sh")
+    if not os.path.isfile(script):
+        print(f"ERROR: {script} not found")
+        return 2
+
+    failures: list[str] = []
+
+    def check(label: str, cond: bool) -> None:
+        print(("  PASS  " if cond else "  FAIL  ") + label)
+        if not cond:
+            failures.append(label)
+
+    ids = ",".join(CODEUNIT_IDS)
+    expected_total = len(CODEUNIT_IDS) * TESTS_PER_CODEUNIT
+
+    with tempfile.TemporaryDirectory() as root:
+        print(f"run-tests.sh batching ({len(CODEUNIT_IDS)} codeunits, "
+              f"{len(ids)} chars):")
+        check("the id list really is over BC's 2048-char field limit",
+              len(ids) > 2048)
+
+        r = run_case(root, script, ids)
+        check("the run succeeds where a single request would be rejected",
+              r.rc == 0)
+        check("no request body exceeds BC's field limit",
+              bool(r.posts) and max(len(p) for p in r.posts) <= 2048)
+        check("the list was actually split into more than one batch",
+              len(r.state["runs"]) > 1)
+        check("every dispatched codeunit is executed exactly once, in order",
+              r.dispatched == CODEUNIT_IDS)
+        merged = r.merged_root()
+        check("the merged report holds one testsuite per codeunit",
+              merged is not None
+              and len(merged.findall("testsuite")) == len(CODEUNIT_IDS))
+        check("the merged roll-up counts every batch's tests",
+              merged is not None and merged.get("tests") == str(expected_total))
+        # bc-test-from-source.yml greps this line and takes the LAST match, so
+        # a per-batch line landing last would report one batch as the run.
+        summary = [ln for ln in r.out.splitlines() if " total, " in ln]
+        check("the LAST summary line is the run total, not a batch's",
+              bool(summary) and summary[-1].startswith(f"{expected_total} total,"))
+        check("the completeness of the batching is stated in the log",
+              f"All {len(CODEUNIT_IDS)} dispatched codeunit(s) reported results"
+              in r.out)
+
+        print("\na lost batch must not read as a smaller green run:")
+        # Third batch's runner exits 0 and writes nothing — the exact shape an
+        # exit-code check cannot see.
+        r2 = run_case(root, script, ids, env={"FAKEBC_DROP_RUN": "3"})
+        check("the run FAILS", r2.rc != 0)
+        check("the lost batch's codeunits are named",
+              "produced NO result at all" in r2.out and "60341" in r2.out)
+        check("the missing batch report is named", "batch report missing" in r2.out)
+
+        print("\na list that fits still behaves like an un-batched run:")
+        r3 = run_case(root, script, "60001,60002,60003")
+        check("it succeeds", r3.rc == 0)
+        check("it makes exactly one suite-setup request", len(r3.posts) == 1)
+        check("it runs the runner exactly once", len(r3.state["runs"]) == 1)
+        check("it still reports a run total",
+              any(ln.startswith("6 total, 6 passed, 0 failed")
+                  for ln in r3.out.splitlines()))
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed: {', '.join(failures)}")
+        return 1
+    print("\nall checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The corpus test suite stopped being able to run on BC 27.x. Every pull request and `master` itself went red on the 27.0, 27.3 and 27.5 legs, failing in "Setting up test suite" before a single test executed:

```
POST .../codeunitRunRequests  HTTP 400
{"error":{"code":"Application_StringExceededLength",
 "message":"The length of the string is 2051, but it must be
            less than or equal to 2048 characters."}}
```

`scripts/run-tests.sh` sends every discovered codeunit id as one comma-separated string, and `CodeunitIds` is `Text[2048]` on table 99903. The AL-language corpus crossed that ceiling at 342 codeunits / 2051 characters. Nothing is wrong with the tests — the list simply got long enough.

Only 27.x is affected, and that was measured rather than assumed. On corpus run `33996871124`, 27.0/27.3/27.5 log `TestRunnerHub not available — using the websocket runner`; 28.0 through 28.4 log `server supports the TestRunnerHub — splitting codeunits`. On 28.0 the websocket leg received 27 codeunits against the hub's 2513, so its string is nowhere near the limit.

## Why batching, and not the two simpler options

**Widening the field** means recompiling the AL extension *and* rebuilding and pushing `bc-runner:latest`, because `src/Dockerfile` bakes `TestRunnerExtension.app` in and `run-tests.sh` only republishes it when the API is absent, which it is not.

**Range-compressing the id list** gives no bound at all — the saving depends entirely on how dense the ids happen to be, so it defers the problem without fixing it.

Batching per request is not possible either: `SetupSuite` calls `InitSuite`, which *clears* the DEFAULT suite. Batches cannot be accumulated and run together, so each one is set up, executed and collected before the next replaces it.

The default budget is **1000 characters**, not 2047. The list has to double before the batch count moves.

## The failure mode this must not have

A batching bug that silently drops a batch looks exactly like success. Four independent guards, each proven to reject its own failure rather than merely proven to accept a good run:

1. `chunk-codeunit-ids.py` verifies the chunks rejoin to exactly the input, in order. Its `--self-test` feeds the verifier deliberately broken chunkings — dropped last chunk, dropped id, duplicate, reorder, empty, over-budget — and asserts each is rejected.
2. `run-tests.sh` asserts `BATCHES_EXECUTED` equals the chunk count.
3. Each batch's runner still checks `codeunitsRun == numCodeunits`, folded into the overall exit code.
4. `merge-junit-batches.py` asserts the merged total equals the sum of batch totals, and that every dispatched codeunit produced a `<testsuite>`.

Guard 4 is fatal when the list was batched and advisory when it was not, so it cannot re-verdict runs this change does not touch.

## Verification

**Local harness, before the fix:** driving the unmodified `run-tests.sh` against a fake BC enforcing the same limit reproduces the identical HTTP 400. After: all 17 checks pass, including a sabotage case where batch 3 exits 0 and writes no report — that run fails loudly and names the missing codeunits.

**Real BC 27.5**, run `34000352378`, conclusion success:

```
Codeunit id list is 2051 chars; BC's CodeunitIds field holds 2048.
Running in 3 batches of at most 1000 chars each.
Executing 166 / 166 / 10 codeunits  ->  1223 + 1292 + 87
All 342 dispatched codeunit(s) reported results across 3 batches.
2602 total, 2602 passed, 0 failed, 0 skipped in 330s
```

The uploaded artifact carries 342 `<testsuite>` elements and 2602 `<testcase>` elements with a root roll-up of `tests="2602"` — consistent three ways. Against the last green 27.5 leg before the break (commit `3ed9b54`): 340 codeunits / 2585 tests / 353 s, versus 342 / 2602 / 330 s here, three corpus pull requests later. Nothing lost, and batching cost nothing measurable.

## Two details worth knowing

Known-failing-test disables are re-applied **per batch**. Each `InitSuite` deletes the `Run=false` flags, so applying them once would silently re-enable everything from batch 2 onward.

The aggregate summary line is printed **last**, because `bc-test-from-source.yml` greps `[0-9]+ total, ... failed` with `tail -1`. A per-batch line landing last would have reported one batch as the whole run.

`run-tests-altool.py` is unchanged, so the TestRunnerHub path is byte-identical.

## One judgement call to check

`--timeout` is now per batch rather than per run, matching how the hybrid runner gives each of its two legs the full timeout. Three batches could in principle take three times the wall limit.

---

*Opened by an agent working for the repository owner.*
