### PR TITLE
fix: retry a null OpenForm result with a fresh connection (#56)

### DIFF
--- a/tools/TestRunner/Program.cs
+++ b/tools/TestRunner/Program.cs
@@ -79,6 +79,9 @@ int odataResultsSeen = 0;
 // Cached across calls — avoid re-resolving company ID and recreating HttpClient
 HttpClient? cachedHttp = null;
 string? cachedCompanyId = null;
+// How many times OpenForm returned a JSON null and a reconnect recovered it (issue #56).
+// Printed at the end of the run, unconditionally, so the rate stays visible.
+int openFormNullRetries = 0;
 // Per-method result records, populated by PrintLiveResults as tests complete.
 // Used to emit JUnit XML at the end of the run when --junit-output is set.
 var recordedResults = new List<RecordedResult>();
@@ -224,9 +227,9 @@ async Task<int> RunTests()
     }
 
     // Initial connection — used only for ClearTestResults before the loop.
-    var (rpc, ws, _) = await Connect(authBytes, tokenCapture, cts.Token);
-    var formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
-    if (formState == null) return 1;
+    var initialSession = await OpenSessionWithRetry(authBytes, tokenCapture, company, cts.Token);
+    if (initialSession == null) return 1;
+    var (rpc, ws, _, formState) = initialSession.Value;
 
     // ClearTestResults once, before the loop.
     Log("Clearing previous results...");
@@ -289,16 +292,15 @@ async Task<int> RunTests()
     {
         if (!haveSession)
         {
-            CancellationTokenSource sessionEndedCts;
             try
             {
-                (rpc, ws, sessionEndedCts) = await Connect(authBytes, tokenCapture, cts.Token);
-                formState = await OpenTestPage(rpc, tokenCapture, company, cts.Token);
-                if (formState == null)
+                var session = await OpenSessionWithRetry(authBytes, tokenCapture, company, cts.Token);
+                if (session == null)
                 {
                     Log("Could not open test page after reconnect");
                     break;
                 }
+                (rpc, ws, _, formState) = session.Value;
                 haveSession = true;
             }
             catch (Exception ex)
@@ -408,6 +410,8 @@ async Task<int> RunTests()
 
     Console.WriteLine($"\n=== Results ({elapsed.TotalSeconds:F0}s) ===");
     Console.WriteLine($"{total} total, {livePassed} passed, {liveFailed} failed, {liveSkipped} skipped");
+    if (openFormNullRetries > 0)
+        Console.Error.WriteLine($"[testrunner] OpenForm returned a null result {openFormNullRetries} time(s) during this run; a reconnect recovered each one (see issue #56).");
     return ComputeExitCode(runCompleted, codeunitsRun, numCodeunits, liveFailed, livePassed);
 }
 
@@ -631,6 +635,40 @@ async Task<JToken?> OpenTestPage(JsonRpc rpc, MetadataTokenCapture tc, string co
     Log($"Page opened ({state?["ServerFormHandle"]})");
     try { var pg = await rpc.InvokeWithCancellationAsync<JToken>("GetPage", new object[] { new { PageSize = 50, IncludeMoreDataInformation = true, IncludeNonRowData = true }, state! }, ct); if (pg?["State"] != null) state = pg["State"]; } catch { }
     return state;
+}
+
+// Opens a fresh WebSocket connection and the test page on it, retrying with a brand
+// new connection when OpenForm comes back null (issue #56). OpenForm returning a JSON
+// null is a JSON-RPC success whose result is null — it never throws, so the caller had
+// no exception to catch and, before this, nothing to retry either. A null result can mean
+// the connection itself is in a bad state, so each attempt opens its own connection
+// rather than retrying OpenForm on the one that just failed.
+//
+// This only retries a null OpenForm result. If Connect() itself throws (the WebSocket
+// handshake or OpenConnection call fails), that exception propagates immediately —
+// no attempts are consumed retrying it. That matches issue #56's scope, which is about
+// the null result specifically; a throwing Connect() is unrelated and already surfaces
+// as an exception the caller can see.
+async Task<(JsonRpc rpc, ClientWebSocket ws, CancellationTokenSource sessionEndedCts, JToken formState)?> OpenSessionWithRetry(
+    byte[] authBytes, MetadataTokenCapture tc, string company, CancellationToken ct, int maxAttempts = 3)
+{
+    for (int attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+        var (rpc, ws, sessionEndedCts) = await Connect(authBytes, tc, ct);
+        var formState = await OpenTestPage(rpc, tc, company, ct);
+        // The returned session's sessionEndedCts is owned by the caller from here,
+        // same as it always was at the two call sites this replaces — only a
+        // discarded (failed) attempt's CTS is disposed below.
+        if (formState != null) return (rpc, ws, sessionEndedCts, formState);
+
+        openFormNullRetries++;
+        Log($"OpenForm returned null on attempt {attempt}/{maxAttempts}; reconnecting.");
+        try { rpc.Dispose(); } catch { }
+        try { ws.Dispose(); } catch { }
+        try { sessionEndedCts.Dispose(); } catch { }
+        if (attempt < maxAttempts) await Task.Delay(TimeSpan.FromSeconds(2), ct);
+    }
+    return null;
 }
 
 class Callbacks


### PR DESCRIPTION
## Summary

`OpenTestPage` in `tools/TestRunner/Program.cs` returns `null` when BC answers `OpenForm` with a JSON null. Both call sites treated that as immediately fatal, with no retry: one transient page-open failure at the start of a run cost the whole websocket leg and every test it was going to run. `OpenForm` returning JSON null is a JSON-RPC success whose result is null, so it never threw and the surrounding `catch` never saw it.

`OpenSessionWithRetry` wraps the `Connect` + `OpenTestPage` pair used at both call sites (the initial connection, and the per-codeunit reconnect loop) and retries up to 3 times with a fresh connection when `OpenForm` comes back null, 2 seconds apart. Each attempt opens its own connection rather than retrying on the one that just failed, since a null result can mean the connection itself is in a bad state. A throwing `Connect()` is unrelated to this and unchanged — it still propagates immediately.

Every retry is logged, and the run prints a one-line summary on stderr when at least one retry happened, so the rate stays visible once this stops failing legs outright.

## Test plan

- [x] `dotnet build -c Release` — clean build, 0 warnings, 0 errors
- [x] `dotnet ... --self-test-exit-code` — unrelated `ComputeExitCode` logic unaffected
- [x] Ran the existing ONRC repro suite through `run-tests.sh` end-to-end against the rebuilt image — non-retry path unaffected
- [x] Verified the retry path itself against a live container with a temporary hook forcing `OpenForm` null: 2 forced failures recover on the 3rd attempt and the run completes normally; 4 forced failures (over the cap) exit 1 cleanly, no hang, no unhandled exception. The hook was removed before committing.

Closes #56

https://claude.ai/code/session_01DxkmeyYvabEBi4WK35FS8T